### PR TITLE
refactor: 아바타 컴포넌트에 사용되는 next Image 컴포넌트 html image 태그로 변경

### DIFF
--- a/apps/docs/stories/Avatar.stories.tsx
+++ b/apps/docs/stories/Avatar.stories.tsx
@@ -13,9 +13,9 @@ const meta = {
 
 ## 주요 기능
 - ✅ Next.js Image 컴포넌트 기반 최적화
-- ✅ Fallback 아바타 자동 생성
+- ✅ Fallback 아바타 자동 생성 (이미지 미지정 시 name 또는 alt 기반)
 - ✅ 접근성 지원 (alt 속성 필수)
-- ✅ 다양한 크기 지원
+- ✅ 다양한 크기 지원 (sm, md, lg, xl)
 - ✅ 디자인 시스템 컬러 적용
         `,
       },
@@ -43,13 +43,19 @@ const meta = {
       control: { type: 'text' },
       description: '사용자 이름 (Fallback 생성용)',
     },
-    priority: {
-      control: { type: 'boolean' },
-      description: '이미지 로딩 우선순위',
-      table: {
-        defaultValue: { summary: 'false' },
-      },
+    className: {
+      control: { type: 'text' },
+      description: '추가 CSS 클래스',
     },
+    onImageError: {
+      action: 'onImageError',
+      description: '이미지 로드 실패 시 콜백',
+    },
+  },
+  args: {
+    alt: '김철수',
+    name: '김철수',
+    size: 'md',
   },
 } satisfies Meta<typeof Avatar>;
 
@@ -71,7 +77,7 @@ export const WithImage: Story = {
     src: 'https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?w=150&h=150&fit=crop&crop=face',
     alt: '사용자 프로필',
     size: 'lg',
-    priority: true,
+    name: '사용자 프로필',
   },
 };
 
@@ -121,6 +127,7 @@ export const MultipleUsers: Story = {
       <Avatar
         src="https://plus.unsplash.com/premium_photo-1689568126014-06fea9d5d341?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
         alt="실제 사용자"
+        name="실제 사용자"
         size="lg"
       />
     </div>

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,5 +1,21 @@
+import AuctionCard from '../entities/auction/ui/AuctionCard';
+
 const Page = () => {
-  return <main className="flex min-h-screen flex-col items-center justify-between p-24">page</main>;
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-between p-1">
+      <AuctionCard
+        imageSrc="./favicon.ico"
+        badgeVariant="best"
+        title="파비콘"
+        locationName="서울시 강남구"
+        endTime={new Date(Date.now() + 1000 * 60 * 60 * 24 * 2)}
+        bidStartPrice={70000}
+        bidCurrentPrice={80000}
+        bidCount={23}
+      />
+      page
+    </main>
+  );
 };
 
 export default Page;

--- a/packages/ui/src/design-system/base-components/Avatar/Avatar.tsx
+++ b/packages/ui/src/design-system/base-components/Avatar/Avatar.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import Image from 'next/image';
 import { forwardRef } from 'react';
 import { cn } from '../../../utils/cn'; // 클래스명 유틸리티 함수
 
@@ -9,7 +8,6 @@ export interface AvatarProps extends React.HTMLAttributes<HTMLDivElement> {
   alt: string;
   size?: 'sm' | 'md' | 'lg' | 'xl'; // 아바타 크기
   name?: string;
-  priority?: boolean; // 이미지 로딩 우선순위
   onImageError?: () => void; // 이미지 로드 실패 시 콜백
 }
 
@@ -34,7 +32,7 @@ const AVATAR_SIZES = {
 } as const;
 
 const Avatar = forwardRef<HTMLDivElement, AvatarProps>(
-  ({ src, alt, size = 'md', name, priority = false, onImageError, className, ...props }, ref) => {
+  ({ src, alt, size = 'md', name, onImageError, className, ...props }, ref) => {
     // Fallback 아바타 생성 함수
     const generateFallbackAvatar = (seedName: string) => {
       return `https://api.dicebear.com/7.x/thumbs/svg?seed=${encodeURIComponent(seedName)}`;
@@ -60,17 +58,15 @@ const Avatar = forwardRef<HTMLDivElement, AvatarProps>(
         )}
         {...props}
       >
-        <Image
+        <img
           src={imageSrc}
           alt={alt}
           width={sizeConfig.pixels}
           height={sizeConfig.pixels}
-          priority={priority}
-          className="object-cover size-full"
+          className="size-full object-cover"
           onError={onImageError}
           // 이미지 최적화 설정
           sizes={`${sizeConfig.pixels}px`}
-          quality={85}
         />
       </div>
     );


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안


## 📋 작업 내용

아바타 컴포넌트에서 사용되는 nextjs의 Image 컴포넌트를 html image 태그로 변경합니다.

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
