### PR TITLE
feat: 경매 리스트 비즈니스 로직 추가

### DIFF
--- a/apps/web/app/api/auction/list/route.ts
+++ b/apps/web/app/api/auction/list/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from 'next/server';
+
+import { adminClient } from '../../../admin';
+
+export async function GET() {
+  try {
+    const { data, error } = await adminClient
+      .from('auction')
+      .select(
+        `
+    *,
+    product:product_id (
+      name,
+      category,
+      description
+    ),
+    seller:seller_id (
+      username,
+      address
+    )
+  `
+      )
+      .order('end_time', { ascending: false });
+
+    if (error) throw error;
+
+    return NextResponse.json(data);
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ error: '데이터를 불러오지 못했습니다' }, { status: 500 });
+  }
+}

--- a/apps/web/entities/auction/ui/AuctionCard.tsx
+++ b/apps/web/entities/auction/ui/AuctionCard.tsx
@@ -4,7 +4,7 @@ import { formatPriceNumber } from '@repo/ui/utils/formatNumberWithComma';
 import { IoPersonOutline } from 'react-icons/io5';
 
 export interface AuctionCardProps extends CardProps {
-  badgeVariant?: 'best' | 'urgent';
+  badgeVariant?: 'best' | 'urgent' | null;
   bidStartPrice: number;
   bidCurrentPrice: number;
   bidCount: number;
@@ -13,6 +13,7 @@ const AuctionCard = ({
   title,
   locationName,
   imageSrc,
+  endTime,
   badgeVariant,
   bidStartPrice,
   bidCurrentPrice,
@@ -27,7 +28,7 @@ const AuctionCard = ({
         badgeVariant={badgeVariant}
         title={title}
         locationName={locationName}
-        endTime={new Date(Date.now() + 1000 * 60 * 60 * 24 * 2)}
+        endTime={endTime}
       />
       {/* 제목 및 입찰 내용 */}
       <section className="mt-4 flex flex-col gap-4">

--- a/apps/web/hooks/useAuctionList.ts
+++ b/apps/web/hooks/useAuctionList.ts
@@ -1,0 +1,37 @@
+import { useQuery } from '@tanstack/react-query';
+
+type AuctionItem = {
+  auction_id: string;
+  start_price: number;
+  current_price: number;
+  start_time: string;
+  end_time: string;
+  thumbnail: string;
+  images: string[];
+  seller_confirm: boolean;
+  buyer_confirm: boolean;
+  bid_count: number;
+  status: string;
+  badge_variant: 'urgent' | 'best' | null;
+  product: {
+    name: string;
+    category: string;
+    description: string;
+  };
+  seller: {
+    username: string;
+    address: string;
+  };
+};
+
+export const useAuctionList = () => {
+  return useQuery<AuctionItem[]>({
+    queryKey: ['auction-list'],
+    queryFn: async () => {
+      const res = await fetch('/api/auction/list');
+      if (!res.ok) throw new Error('경매 목록을 불러오지 못했습니다');
+      return res.json();
+    },
+    staleTime: 1000 * 60 * 5, // 5분 동안 캐시 유지
+  });
+};

--- a/apps/web/mock/auction.ts
+++ b/apps/web/mock/auction.ts
@@ -35,6 +35,7 @@ export const mockListings = [
 ];
 
 export const categories = [
+  { title: '전체' },
   { title: '가전' },
   { title: '스포츠용품' },
   { title: '취미' },

--- a/apps/web/pages/auction-list-page/ui/index.tsx
+++ b/apps/web/pages/auction-list-page/ui/index.tsx
@@ -1,31 +1,74 @@
 'use client';
 
+import { useState } from 'react';
+
 import { Category } from '@repo/ui/design-system/base-components/Category/index';
 import { LocationInfo } from '@repo/ui/design-system/base-components/LocationInfo/index';
 
-import { categories, mockListings } from '../../../mock/auction';
+import { useAuctionList } from '../../../hooks/useAuctionList';
+import { categories } from '../../../mock/auction';
 import { AuctionListings } from '../../../widgets/auction-listings';
 
 export const AuctionListPage = () => {
   const locationName = '서울시 강남구';
+  const { data: auctionList, isLoading, isError } = useAuctionList();
+  const [selectedCategory, setSelectedCategory] = useState<string>('all');
+  const [selectedBadge, setSelectedBadge] = useState<string>('all');
+  // API 데이터 → AuctionListings용 데이터로 변환
+  const mappedList = (auctionList || []).map((item) => ({
+    id: item.auction_id,
+    bidStartPrice: item.start_price,
+    bidCurrentPrice: item.current_price,
+    bidCount: item.bid_count,
+    status: item.status,
+    imageSrc: item.thumbnail,
+    title: item.product.name,
+    category: item.product.category,
+    description: item.product.description,
+    badgeVariant: item.badge_variant,
+    seller: {
+      username: item.seller.username,
+      address: item.seller.address,
+    },
+    locationName: item.seller.address,
+    startTime: item.start_time,
+    endTime: item.end_time,
+  }));
+
+  let filteredList = mappedList;
+  if (!(selectedCategory === 'all' || selectedCategory === '전체')) {
+    filteredList = filteredList.filter((item) => item.category === selectedCategory);
+  }
+  if (selectedBadge !== 'all') {
+    filteredList = filteredList.filter((item) => item.badgeVariant === selectedBadge);
+  }
   return (
-    <main className="flex min-h-screen w-full flex-col items-center justify-between p-1">
+    <main className="flex min-h-screen w-full flex-col items-center p-1">
       <div className="mr-auto flex items-center gap-1">
         <LocationInfo locationName={locationName}></LocationInfo>
       </div>
-      <Category categories={categories} />
+      <Category
+        categories={categories}
+        onCategoryClick={(cat) => setSelectedCategory(cat === '전체' ? 'all' : cat)}
+      />
       <select
         name="listFilter"
         id="actionListFilter"
         className="text-neutral-70 my-2 ml-auto mr-4 w-1/2 rounded-sm p-1 shadow-md"
+        value={selectedBadge}
+        onChange={(e) => setSelectedBadge(e.target.value)}
       >
-        <option value="all" selected>
-          전체 보기
-        </option>
+        <option value="all">전체 보기</option>
         <option value="best">인기</option>
-        <option value="urgent">마감순</option>
+        <option value="urgent">마감 임박</option>
       </select>
-      <AuctionListings listData={mockListings} />
+      {isLoading ? (
+        <div className="my-8">경매 목록을 불러오는 중...</div>
+      ) : isError ? (
+        <div className="my-8 text-red-500">경매 목록을 불러오지 못했습니다.</div>
+      ) : (
+        <AuctionListings listData={filteredList} />
+      )}
     </main>
   );
 };

--- a/apps/web/widgets/auction-listings/ui/AuctionListings.tsx
+++ b/apps/web/widgets/auction-listings/ui/AuctionListings.tsx
@@ -1,3 +1,5 @@
+import Link from 'next/link';
+
 import AuctionCard, { AuctionCardProps } from '../../../entities/auction/ui/AuctionCard';
 
 interface MockAuctionCardProps extends AuctionCardProps {
@@ -12,17 +14,19 @@ export const AuctionListings = ({ listData }: { listData: MockAuctionCardProps[]
       {/* 경매 아이템 목록 */}
       <div className="space-y-4">
         {listData.map((item) => (
-          <AuctionCard
-            key={item.id}
-            imageSrc={item.imageSrc}
-            badgeVariant={item.badgeVariant}
-            title={item.title}
-            locationName={item.locationName}
-            endTime={item.endTime}
-            bidStartPrice={item.bidStartPrice}
-            bidCurrentPrice={item.bidCurrentPrice}
-            bidCount={item.bidCount}
-          />
+          <Link href={`/auction/${item.id}`} key={item.id} className="block">
+            <AuctionCard
+              key={item.id}
+              imageSrc={item.imageSrc}
+              badgeVariant={item.badgeVariant}
+              title={item.title}
+              locationName={item.locationName}
+              endTime={item.endTime}
+              bidStartPrice={item.bidStartPrice}
+              bidCurrentPrice={item.bidCurrentPrice}
+              bidCount={item.bidCount}
+            />
+          </Link>
         ))}
       </div>
 
@@ -31,9 +35,11 @@ export const AuctionListings = ({ listData }: { listData: MockAuctionCardProps[]
         <div className="flex flex-col items-center justify-center py-16 text-center">
           <h3 className="text-neutral-70 mb-2 text-lg font-medium">등록된 경매 상품이 없습니다</h3>
           <p className="text-neutral-40 mb-6">첫 번째 경매 상품을 등록해보세요</p>
-          <button className="cursor-pointer rounded-lg bg-[var(--color-primary-500)] px-6 py-2 font-medium text-white">
-            상품 등록하기
-          </button>
+          <Link href="/auction/auction-add">
+            <button className="cursor-pointer rounded-lg bg-[var(--color-primary-500)] px-6 py-2 font-medium text-white">
+              상품 등록하기
+            </button>
+          </Link>
         </div>
       )}
     </section>

--- a/packages/ui/src/design-system/base-components/Card/Card.tsx
+++ b/packages/ui/src/design-system/base-components/Card/Card.tsx
@@ -4,7 +4,7 @@ import { Badge } from '../Badge';
 import { LocationInfo } from '../LocationInfo';
 export interface CardProps {
   imageSrc: string;
-  badgeVariant?: 'best' | 'urgent';
+  badgeVariant?: 'best' | 'urgent' | null;
   title: string;
   locationName: string;
   endTime: Date | string;
@@ -12,7 +12,8 @@ export interface CardProps {
 
 const Card = ({ imageSrc, badgeVariant, title, locationName, endTime }: CardProps) => {
   const leftTime = getTimeLeftString(endTime);
-  const badgeTitle = badgeVariant === 'best' ? '인기' : '마감임박';
+  const badgeTitle =
+    badgeVariant === 'best' ? '인기' : badgeVariant === 'urgent' ? '마감임박' : null;
   return (
     <div>
       <section>
@@ -24,7 +25,7 @@ const Card = ({ imageSrc, badgeVariant, title, locationName, endTime }: CardProp
             </Badge>
           )}
         </div>
-        <div className="flex items-center justify-between p-4">
+        <div className="flex items-center justify-between">
           <LocationInfo locationName={locationName} />
           <div className="text-neutral-70 flex items-center gap-1">
             <FaRegClock />

--- a/packages/ui/src/design-system/base-components/Category/Category.tsx
+++ b/packages/ui/src/design-system/base-components/Category/Category.tsx
@@ -7,9 +7,10 @@ import { Swiper, SwiperSlide } from 'swiper/react';
 export interface CategoryProps {
   categories: { title: string }[];
   className?: string;
+  onCategoryClick?: (cat: string) => void;
 }
 
-export default function Category({ categories, className }: CategoryProps) {
+export default function Category({ categories, className, onCategoryClick }: CategoryProps) {
   return (
     <div className={`w-full ${className ?? ''}`}>
       <Swiper
@@ -21,7 +22,10 @@ export default function Category({ categories, className }: CategoryProps) {
       >
         {categories.map((item, i) => (
           <SwiperSlide key={i}>
-            <div className="flex w-[58px] flex-col items-center justify-center text-center">
+            <div
+              className="flex w-[58px] cursor-pointer flex-col items-center justify-center text-center"
+              onClick={() => onCategoryClick?.(item.title)}
+            >
               <div className="border-primary-200 bg-primary-50 flex h-[58px] w-[58px] items-center justify-center rounded-full border-2">
                 <MdLocationPin className="h-6 w-6 text-gray-500" />
               </div>


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes  -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

경매 리스트 페이지에 supabase 테이블들의 데이터를 통해 리스트 출력할 수 있도록 연동했습니다.
비즈니스 로직 구현하면서 supabase 내 뱃지 (인기, 마감 임박) 관련 badge_variant 칼럼을 추가하였고
입찰 수 5개 이상일 경우 인기(best), 마감 1시간 이내 경매는 마감 임박(urgent) 값이 입력되도록 trigger  지정하였습니다.
관련하여 기존 best, urgent만 입력 받던 badge를 null 값을 추가하여 db 상 빈 값일 경우를 고려했습니다.

또한 필터 관련하여 카테고리 데이터에 전체 항목을 추가, 전체를 클릭 시 전체 항목이 보이도록 변경하였습니다.


## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
