### PR TITLE
fix: 아바타 업로드 시 기존 파일 정리 로직 추가

### DIFF
--- a/apps/web/features/profile/ui/ProfileAvatarUpload.tsx
+++ b/apps/web/features/profile/ui/ProfileAvatarUpload.tsx
@@ -33,6 +33,10 @@ export const ProfileAvatarUpload = ({
       const fileExt = file.name.split('.').pop();
       const filePath = `${id}.${fileExt}`;
 
+      // 기존 파일 모두 삭제
+      const exts = ['jpg', 'jpeg', 'png', 'gif', 'webp'];
+      await supabase.storage.from('avatars').remove(exts.map((ext) => `${id}.${ext}`));
+
       const { data, error: uploadError } = await supabase.storage
         .from('avatars')
         .upload(filePath, file, {


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 문제 설명
아바타 이미지 업로드 시 upsert 옵션을 사용하여 같은 파일명일 경우 덮어쓰기가 되지만, 확장자가 다른 경우 기존 파일이 삭제되지 않아 여러 확장자의 파일이 누적되는 문제가 발생합니다.

## 재현 단계
1. 사용자가 `user123.jpg` 파일을 업로드
2. 동일한 사용자가 `user123.png` 파일을 업로드
3. 스토리지에 `user123.jpg`와 `user123.png` 파일이 모두 존재하게 됨

## 예상 동작
새로운 아바타 이미지 업로드 시 기존에 업로드된 모든 확장자의 아바타 파일이 삭제되고 새 파일만 남아야 함

## 현재 동작
upsert 옵션으로 인해 같은 파일명+확장자만 덮어쓰여지고, 다른 확장자의 파일들은 그대로 남아있음

## 영향
- 스토리지 용량 낭비
- 일관성 없는 아바타 파일 관리

### 변경 사항
- 아바타 업로드 전 기존 파일들을 모든 확장자에 대해 삭제하는 로직 추가
- 지원하는 이미지 확장자: jpg, jpeg, png, gif, webp

### 구현 내용
```javascript
// 기존 파일 모두 삭제
const exts = ['jpg', 'jpeg', 'png', 'gif', 'webp'];
await supabase.storage.from('avatars').remove(exts.map((ext) => `${id}.${ext}`));
```
