### PR TITLE
[feat] : 경매 종료 관련 오버레이 작업

### DIFF
--- a/apps/web/app/(main)/auction/[auctionId]/auction-detail/page.tsx
+++ b/apps/web/app/(main)/auction/[auctionId]/auction-detail/page.tsx
@@ -82,6 +82,9 @@ const Page = () => {
   const remainingTime = getTimeLeftString(data.end_time);
 
   const minusBidCost = () => {
+    if (data.status === 'ready') {
+      return alert('경매가 시작되지 않았습니다. 입찰을 진행할 수 없습니다.');
+    }
     setIsUserChanged(true);
     setBidCost((prev: number) => {
       const newCostNumber = prev - bidUnit;
@@ -92,11 +95,18 @@ const Page = () => {
   };
 
   const plusBidCost = () => {
+    if (data.status === 'ready') {
+      return alert('경매가 시작되지 않았습니다. 입찰을 진행할 수 없습니다.');
+    }
+
     setIsUserChanged(true);
     setBidCost((prev: number) => prev + bidUnit);
   };
 
   const sendBid = () => {
+    if (data.status === 'ready') {
+      return alert('경매가 시작되지 않았습니다. 입찰을 진행할 수 없습니다.');
+    }
     if (data.seller_id === bidderId) {
       return alert('본인의 경매에는 입찰할 수 없습니다.');
     }
@@ -111,7 +121,7 @@ const Page = () => {
   };
 
   return (
-    <main className="flex w-full flex-col items-center justify-center gap-2.5" role="main">
+    <main className="relative flex w-full flex-col items-center justify-center gap-2.5" role="main">
       <ImageBanner images={imageFiles} height={230} />
       <h1 className="text-neutral-70 mr-auto mt-5 font-semibold">{auctionName}</h1>
       <AuctionDetailCard
@@ -121,12 +131,20 @@ const Page = () => {
         minBidCost={minBidCostNumber}
         bidUnit={bidUnit}
         bidCost={bidCost}
+        isProgressing={data.status === 'in progress'}
         onMinus={minusBidCost}
         onPlus={plusBidCost}
         onClick={sendBid}
       />
       <AuctionSellerProfile user={seller} />
       <AuctionDescriptionCard bids={displayBids} description={product.description} />
+      {data.status === 'end' && (
+        <div className="pointer-events-auto absolute inset-0 z-10 bg-black/50">
+          <div className="absolute inset-0 flex items-center justify-center text-white">
+            <p className="text-lg font-bold">경매가 종료되었습니다.</p>
+          </div>
+        </div>
+      )}
     </main>
   );
 };

--- a/apps/web/app/(main)/auction/[auctionId]/auction-detail/page.tsx
+++ b/apps/web/app/(main)/auction/[auctionId]/auction-detail/page.tsx
@@ -12,6 +12,8 @@ import {
 } from '@/widgets/auction-detail-card';
 import { ImageBanner } from '@/widgets/image-banner';
 
+import { AuctionOverlay } from '@/features/auction/ui/AuctionOverlay';
+
 import { useAuctionBid } from '@/hooks/useAuctionBid';
 import { useAuctionDetail } from '@/hooks/useAuctionDetail';
 import { useRealtimeBids } from '@/hooks/useRealTimeBid';
@@ -138,13 +140,7 @@ const Page = () => {
       />
       <AuctionSellerProfile user={seller} />
       <AuctionDescriptionCard bids={displayBids} description={product.description} />
-      {data.status === 'end' && (
-        <div className="pointer-events-auto absolute inset-0 z-10 bg-black/50">
-          <div className="absolute inset-0 flex items-center justify-center text-white">
-            <p className="text-lg font-bold">경매가 종료되었습니다.</p>
-          </div>
-        </div>
-      )}
+      {data.status === 'end' && <AuctionOverlay overlayText="경매가 종료되었습니다." />}
     </main>
   );
 };

--- a/apps/web/app/api/auction/detail/[auctionId]/route.ts
+++ b/apps/web/app/api/auction/detail/[auctionId]/route.ts
@@ -22,7 +22,19 @@ export async function GET(req: NextRequest, { params }: { params: { auctionId: s
       .eq('auction_id', auctionId)
       .single();
     if (error) throw error;
-    return NextResponse.json({ data });
+
+    // status 계산 (기존 status 필드가 있어도 서버 계산값으로 덮어씀)
+    let status: 'ready' | 'in progress' | 'end' = 'ready';
+    const now = new Date();
+    const start = data.start_time ? new Date(data.start_time) : null;
+    const end = data.end_time ? new Date(data.end_time) : null;
+    if (start && end) {
+      if (now < start) status = 'ready';
+      else if (now >= start && now <= end) status = 'in progress';
+      else if (now > end) status = 'end';
+    }
+    const { status: oldStatus, ...rest } = data;
+    return NextResponse.json({ data: { ...rest, status } });
   } catch (error) {
     return NextResponse.json(
       { error: typeof error === 'string' ? error : JSON.stringify(error) },

--- a/apps/web/app/api/auction/list/route.ts
+++ b/apps/web/app/api/auction/list/route.ts
@@ -24,7 +24,22 @@ export async function GET() {
 
     if (error) throw error;
 
-    return NextResponse.json(data);
+    // status 계산 및 덮어쓰기
+    const now = new Date();
+    const result = (data || []).map((item: any) => {
+      let status: 'ready' | 'in progress' | 'end' = 'ready';
+      const start = item.start_time ? new Date(item.start_time) : null;
+      const end = item.end_time ? new Date(item.end_time) : null;
+      if (start && end) {
+        if (now < start) status = 'ready';
+        else if (now >= start && now <= end) status = 'in progress';
+        else if (now > end) status = 'end';
+      }
+      const { status: oldStatus, ...rest } = item;
+      return { ...rest, status };
+    });
+
+    return NextResponse.json(result);
   } catch (err) {
     console.error(err);
     return NextResponse.json({ error: '데이터를 불러오지 못했습니다' }, { status: 500 });

--- a/apps/web/features/auction/ui/AuctionBidHistoryCard.tsx
+++ b/apps/web/features/auction/ui/AuctionBidHistoryCard.tsx
@@ -1,6 +1,6 @@
 import { formatPriceNumber } from '@repo/ui/utils/formatNumberWithComma';
 
-import { Bid } from '../../../types/db';
+import { Bid } from '@/types/db';
 
 export const AuctionBidHistoryCard = ({ bid }: { bid: Bid }) => {
   const dateObj = new Date(bid.bid_time);

--- a/apps/web/features/auction/ui/AuctionCard.tsx
+++ b/apps/web/features/auction/ui/AuctionCard.tsx
@@ -22,7 +22,7 @@ const AuctionCard = ({
   const startPrice = formatPriceNumber(bidStartPrice);
   const currentPrice = formatPriceNumber(bidCurrentPrice);
   return (
-    <div className="border-neutral-20 w-full rounded-lg border p-4 shadow-md">
+    <div className="border-neutral-20 relative w-full rounded-lg border p-4 shadow-md">
       <Card
         imageSrc={imageSrc}
         badgeVariant={badgeVariant}

--- a/apps/web/features/auction/ui/AuctionImageUploader.tsx
+++ b/apps/web/features/auction/ui/AuctionImageUploader.tsx
@@ -4,7 +4,7 @@ import React, { useRef } from 'react';
 
 import { IoIosAddCircleOutline, IoMdCloseCircle } from 'react-icons/io';
 
-import { supabase } from '../../../lib/supabase/supabase';
+import { supabase } from '@/lib/supabase/supabase';
 
 interface AuctionImageUploaderProps {
   images: string[];

--- a/apps/web/features/auction/ui/AuctionOverlay.tsx
+++ b/apps/web/features/auction/ui/AuctionOverlay.tsx
@@ -1,0 +1,9 @@
+export const AuctionOverlay = ({ overlayText }: { overlayText: string }) => {
+  return (
+    <div className="pointer-events-auto absolute inset-0 z-10 bg-black/50">
+      <div className="absolute inset-0 flex items-center justify-center text-white">
+        <p className="text-lg font-bold">{overlayText}</p>
+      </div>
+    </div>
+  );
+};

--- a/apps/web/widgets/auction-detail-card/ui/AuctionDescriptionCard.tsx
+++ b/apps/web/widgets/auction-detail-card/ui/AuctionDescriptionCard.tsx
@@ -1,8 +1,9 @@
 'use client';
 import { useState } from 'react';
 
-import { AuctionBidHistoryCard } from '../../../features/auction/ui/AuctionBidHistoryCard';
-import { Bid } from '../../../types/db';
+import { AuctionBidHistoryCard } from '@/features/auction/ui/AuctionBidHistoryCard';
+
+import { Bid } from '@/types/db';
 
 export const AuctionDescriptionCard = ({
   bids,

--- a/apps/web/widgets/auction-detail-card/ui/AuctionDetailCard.tsx
+++ b/apps/web/widgets/auction-detail-card/ui/AuctionDetailCard.tsx
@@ -11,6 +11,7 @@ interface AuctionDetailCardProps {
   minBidCost: number;
   bidUnit: number;
   bidCost: number;
+  isProgressing?: boolean;
   onMinus: () => void;
   onPlus: () => void;
   onClick: () => void;
@@ -23,6 +24,7 @@ export const AuctionDetailCard = ({
   minBidCost,
   bidUnit,
   bidCost,
+  isProgressing,
   onMinus,
   onPlus,
   onClick,
@@ -36,11 +38,11 @@ export const AuctionDetailCard = ({
         <p className="text-xs text-red-500">남은 시간 : {remainingTime}</p>
       </div>
       <div className="text-neutral-70 my-6 flex items-center gap-5 font-bold">
-        <Button variants="outline" onClick={onMinus}>
+        <Button variants="outline" onClick={onMinus} disabled={!isProgressing}>
           <FaMinus />
         </Button>
         {formatPriceNumber(bidCost)}원
-        <Button variants="outline" onClick={onPlus}>
+        <Button variants="outline" onClick={onPlus} disabled={!isProgressing}>
           <FaPlus />
         </Button>
       </div>
@@ -48,7 +50,13 @@ export const AuctionDetailCard = ({
         <p>최소입찰가 : {formatPriceNumber(minBidCost)}원</p>
         <p>입찰 단위 : {formatPriceNumber(bidUnit)}원</p>
       </div>
-      <Button variants="primary" size="thinLg" className="mt-2" onClick={onClick}>
+      <Button
+        variants="primary"
+        size="thinLg"
+        className="mt-2"
+        onClick={onClick}
+        disabled={!isProgressing}
+      >
         입찰하기
       </Button>
     </section>

--- a/apps/web/widgets/auction-detail-card/ui/AuctionSellerProfile.tsx
+++ b/apps/web/widgets/auction-detail-card/ui/AuctionSellerProfile.tsx
@@ -1,7 +1,7 @@
 import { Avatar } from '@repo/ui/design-system/base-components/Avatar/index';
 import { LocationInfo } from '@repo/ui/design-system/base-components/LocationInfo/index';
 
-import { AuctionDetail } from '../../../types/db';
+import { AuctionDetail } from '@/types/db';
 
 interface AuctionSellerProfileProps {
   user: AuctionDetail['seller'];

--- a/apps/web/widgets/auction-listings/ui/AuctionListings.tsx
+++ b/apps/web/widgets/auction-listings/ui/AuctionListings.tsx
@@ -1,9 +1,11 @@
 import Link from 'next/link';
 
-import AuctionCard, { AuctionCardProps } from '../../../features/auction/ui/AuctionCard';
+import AuctionCard, { AuctionCardProps } from '@/features/auction/ui/AuctionCard';
+import { AuctionOverlay } from '@/features/auction/ui/AuctionOverlay';
 
 interface MockAuctionCardProps extends AuctionCardProps {
   id: string;
+  status: string; // 경매 상태
 }
 
 export const AuctionListings = ({ listData }: { listData: MockAuctionCardProps[] }) => {
@@ -14,19 +16,22 @@ export const AuctionListings = ({ listData }: { listData: MockAuctionCardProps[]
       {/* 경매 아이템 목록 */}
       <div className="space-y-4">
         {listData.map((item) => (
-          <Link href={`/auction/${item.id}/auction-detail`} key={item.id} className="block">
-            <AuctionCard
-              key={item.id}
-              imageSrc={item.imageSrc}
-              badgeVariant={item.badgeVariant}
-              title={item.title}
-              locationName={item.locationName}
-              endTime={item.endTime}
-              bidStartPrice={item.bidStartPrice}
-              bidCurrentPrice={item.bidCurrentPrice}
-              bidCount={item.bidCount}
-            />
-          </Link>
+          <section key={item.id} className="relative">
+            <Link href={`/auction/${item.id}/auction-detail`} key={item.id} className="block">
+              <AuctionCard
+                key={item.id}
+                imageSrc={item.imageSrc}
+                badgeVariant={item.badgeVariant}
+                title={item.title}
+                locationName={item.locationName}
+                endTime={item.endTime}
+                bidStartPrice={item.bidStartPrice}
+                bidCurrentPrice={item.bidCurrentPrice}
+                bidCount={item.bidCount}
+              />
+            </Link>
+            {item.status === 'end' && <AuctionOverlay overlayText="경매가 종료되었습니다." />}
+          </section>
         ))}
       </div>
 


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용
경매 종료 시간 이후 랜더링 되는 경매 리스트, 경매 상세 페이지에서 보이는 화면들에 오버레이 작업을 했습니다.

경매 종료 후 채팅방 생성 과정에서 ui적으로 경매 상세 페이지에서 할 수 있는 것이 없다고 판단 
어떻게 채팅방을 생성할지 월요일 회의 시간에 논의가 필요해 보입니다.
백엔드 상에서 처리가 필요할 것으로 생각되긴 합니다.

추가로 경매 종료 된 경매들을 리스트에서 출력해 줄 필요가 있을까? 라는 생각이 좀 듭니다. 여러분들의 의견이 궁금합니다.
마지막으로 종료 된 경매 상세 페이지에서 낙찰자와 등록한 사용자가 접근 했을 때, 할 수 있는 기능의 추가가 필요할지 여부도 논의를 해보면 좋을 것 같습니다.

결론적으로 우선 db상의 경매 시작, 종료 시간 별로 현재 시간 비례하여 계산하여 fetch할 때 status를 계산하도록 수정하였고, 
각 status 별 
시작 전 -경매 페이지 접근은 가능하나 버튼 조작(입찰가, 입찰)은 불가능
시작 이후 - 기존과 동일
종료 이후 - 리스트를 통한 접근 제한(Link 태그 동작 안 하도록 설정) 및 url을 통한 상세 페이지 접근 시에도 페이지 접근 외 기능은 사용 불가
위와 같은 방식으로 구현해 놨습니다.
구현 모습은 아래 스크린 샷을 통해 확인 가능합니다.
## 🔧 변경 사항

## 📸 스크린샷 (선택 사항)
- 경매 리스트 페이지
![image](https://github.com/user-attachments/assets/d28310db-06a0-48fa-9058-4cc676bc2952)

- 경매 상세 페이지
![image](https://github.com/user-attachments/assets/e35eacc9-06eb-428e-bc93-aa2466382545)

## 📄 기타
