### PR TITLE
Feat/header #107

### DIFF
--- a/apps/web/app/(main)/layout.tsx
+++ b/apps/web/app/(main)/layout.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { Footer } from '../../widgets/footer';
 import { Header } from '../../widgets/header';
 import { LocationModal, NotificationModal } from '../../widgets/modal';

--- a/apps/web/widgets/header/ui/Header.tsx
+++ b/apps/web/widgets/header/ui/Header.tsx
@@ -9,6 +9,7 @@ import { useModalStore } from '../../../stores/modal';
 export const Header = () => {
   const pathname = usePathname();
   const router = useRouter();
+
   const { setOpenModal } = useModalStore();
 
   const noBackButtonRoutes = ['/main'];

--- a/apps/web/widgets/modal/ui/LocationModal.tsx
+++ b/apps/web/widgets/modal/ui/LocationModal.tsx
@@ -1,4 +1,4 @@
-import { useModalStore } from '../../../stores/modal';
+'use client';
 import {
   Item,
   ItemBadge,
@@ -11,6 +11,8 @@ import {
   ModalHeader,
 } from '@repo/ui/design-system/base-components/Modal/index';
 import { IoShieldCheckmarkSharp } from 'react-icons/io5';
+
+import { useModalStore } from '../../../stores/modal';
 
 export const LocationModal = () => {
   const { isModalOpen, closeModal } = useModalStore();

--- a/apps/web/widgets/modal/ui/NotificationModal.tsx
+++ b/apps/web/widgets/modal/ui/NotificationModal.tsx
@@ -1,9 +1,5 @@
-import {
-  Modal,
-  ModalContent,
-  ModalHeader,
-} from '@repo/ui/design-system/base-components/Modal/index';
-import { useModalStore } from '../../../stores/modal';
+'use client';
+
 import {
   Item,
   ItemBadge,
@@ -11,8 +7,15 @@ import {
   ItemFooter,
   ItemTitle,
 } from '@repo/ui/design-system/base-components/Item/index';
+import {
+  Modal,
+  ModalContent,
+  ModalHeader,
+} from '@repo/ui/design-system/base-components/Modal/index';
 import { IoAlertCircleOutline } from 'react-icons/io5';
 import { RiAuctionLine } from 'react-icons/ri';
+
+import { useModalStore } from '../../../stores/modal';
 
 // 타입 정의
 interface NotificationItem {


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용
### 헤더 뒤로가기 버튼 추가 (메인 페이지 제외)
![{5AA07872-59AC-468B-9482-B2F03F9222DF}](https://github.com/user-attachments/assets/1a5f9d4e-251e-41ff-aba0-337b8b27bcd7)
- next.js의 `useRouter` -> `router.back()`으로 구현하였습니다. 
- 현재 위치한 경로는 next.js의 `usePathname` 함수를 이용했습니다. 
- 메인 페이지 외에도 뒤로가기 버튼이 필요없는 페이지를 추가 구현할 경우를 대비하였습니다. 
```typescript
  const noBackButtonRoutes = ['/main'];
  const showBackButton = !noBackButtonRoutes.includes(pathname);
```

## 🔧 변경 사항
- layout.tsx의 `'use client'` 지시문을 삭제하고 자식 컴포넌트들 각각` 'use client'` 지시문을 추가하였습니다. 
  - 클라이언트와 상호작용이 필요한 부분만 `'use client'`를 쓰는게 맞다고 판단하여 변경했습니다. 
## 📸 스크린샷 (선택 사항)

## 📄 기타
