### PR TITLE
refactor: chat 페이지 - css 스타일 상수화 (#99)

### DIFF
--- a/apps/web/features/chat-list/ui/ChatRoomItem.tsx
+++ b/apps/web/features/chat-list/ui/ChatRoomItem.tsx
@@ -1,7 +1,10 @@
 'use client';
 
+import { cn } from '@repo/ui/utils/cn';
 import { useRouter } from 'next/navigation';
 import { FaLocationDot } from 'react-icons/fa6';
+
+import { itemStyles, textStyles } from './styles/ChatRoomItem.styles';
 
 type ChatRoom = {
   room_id: string;
@@ -27,29 +30,27 @@ export const ChatRoomItem = ({ room, currentUserId }: Props) => {
 
   return (
     <li
-      className="group relative h-[93px] w-full cursor-pointer overflow-hidden rounded-[6px] border border-white/10 bg-[#BEAFFC] px-4 py-3 shadow-[0_6px_12px_-2px_rgba(0,0,0,0.2)] backdrop-blur-sm transition active:bg-[#7251F8]"
+      className={cn(itemStyles.base, itemStyles.bg, itemStyles.activeBg)}
       onClick={() => router.push(`/chat/${room.room_id}`)}
     >
       <div className="flex h-full flex-col justify-between">
         {/* 상단: 상품명, 닉네임 */}
         <div className="flex flex-col gap-[2px] overflow-hidden">
-          <div className="truncate text-sm font-semibold text-white">{room.product_name}</div>
-          <div className="truncate text-xs text-white">{opponentNickname}</div>
+          <div className={textStyles.productName}>{room.product_name}</div>
+          <div className={textStyles.opponentNickname}>{opponentNickname}</div>
         </div>
 
         {/* 하단: 위치와 낙찰가 (양쪽 정렬) */}
         <div className="flex items-end justify-between">
-          <div className="flex items-center gap-1 truncate text-xs text-white">
-            <span className="leading-none text-pink-500">
+          <div className={textStyles.location}>
+            <span className={textStyles.locationIcon}>
               <FaLocationDot />
             </span>
             <span>서울시 강남구</span>
           </div>
           <div className="whitespace-nowrap text-right">
-            <p className="mb-[2px] text-[10px] leading-none text-[#656565] group-active:text-white">
-              낙찰가
-            </p>
-            <p className="text-base font-bold leading-tight text-white">50,000원</p>
+            <p className={textStyles.priceLabel}>낙찰가</p>
+            <p className={textStyles.price}>50,000원</p>
           </div>
         </div>
       </div>

--- a/apps/web/features/chat-list/ui/ChatRoomList.tsx
+++ b/apps/web/features/chat-list/ui/ChatRoomList.tsx
@@ -1,19 +1,25 @@
 'use client';
 
-import { ChatRoomItem } from './ChatRoomItem';
-
 import { useChatList } from '@/hooks/chat/useChatList';
+
+import { ChatRoomItem } from './ChatRoomItem';
+import {
+  containerStyles,
+  errorStyles,
+  listStyles,
+  titleStyles,
+} from './styles/ChatRoomList.styles';
 
 export const ChatRoomList = ({ currentUserId }: { currentUserId: string }) => {
   const { data: chatRooms, isLoading, isError, error } = useChatList(currentUserId);
 
-  if (isLoading) return <div className="p-4">로딩 중...</div>;
-  if (isError) return <div className="p-4 text-red-500">에러: {error.message}</div>;
+  if (isLoading) return <div className={containerStyles}>로딩 중...</div>;
+  if (isError) return <div className={errorStyles}>에러: {error.message}</div>;
 
   return (
-    <div className="p-4">
-      <h2 className="mb-4 text-xl font-bold">내 채팅방</h2>
-      <ul className="space-y-2">
+    <div className={containerStyles}>
+      <h2 className={titleStyles}>내 채팅방</h2>
+      <ul className={listStyles}>
         {chatRooms?.map((room) => (
           <ChatRoomItem key={room.room_id} room={room} currentUserId={currentUserId} />
         ))}

--- a/apps/web/features/chat-list/ui/styles/ChatRoomItem.styles.ts
+++ b/apps/web/features/chat-list/ui/styles/ChatRoomItem.styles.ts
@@ -1,0 +1,14 @@
+export const itemStyles = {
+  base: 'group relative h-[93px] w-full cursor-pointer overflow-hidden rounded-[6px] border border-white/10 px-4 py-3 shadow-[0_6px_12px_-2px_rgba(0,0,0,0.2)] backdrop-blur-sm transition',
+  bg: 'bg-[var(--button-secondary-bg)]',
+  activeBg: 'active:bg-[var(--button-secondary-bg-active)]',
+};
+
+export const textStyles = {
+  productName: 'truncate text-sm font-semibold text-[var(--button-primary-text)]',
+  opponentNickname: 'truncate text-xs text-[var(--button-primary-text)]',
+  location: 'flex items-center gap-1 truncate text-xs text-[var(--button-primary-text)]',
+  locationIcon: 'leading-none text-[var(--text-accent)]',
+  priceLabel: 'mb-[2px] text-[10px] leading-none text-[var(--text-secondary)] group-active:text-[var(--button-primary-text)]',
+  price: 'text-base font-bold leading-tight text-[var(--button-primary-text)]',
+};

--- a/apps/web/features/chat-list/ui/styles/ChatRoomList.styles.ts
+++ b/apps/web/features/chat-list/ui/styles/ChatRoomList.styles.ts
@@ -1,0 +1,4 @@
+export const containerStyles = 'p-4';
+export const errorStyles = 'p-4 text-[var(--text-error)]';
+export const titleStyles = 'mb-4 text-xl font-bold';
+export const listStyles = 'space-y-2';

--- a/apps/web/features/chat-room/ui/ChatInput.tsx
+++ b/apps/web/features/chat-room/ui/ChatInput.tsx
@@ -2,7 +2,11 @@
 
 import { useState } from 'react';
 
+import { cn } from '@repo/ui/utils/cn';
+
 import { useSendMessage } from '../../../hooks/chat/useSendMessage';
+
+import { buttonStyles, inputContainerStyles, inputStyles } from './styles/ChatInput.styles';
 
 export const ChatInput = ({ roomId, senderId }: { roomId: string; senderId: string }) => {
   const [message, setMessage] = useState('');
@@ -28,18 +32,25 @@ export const ChatInput = ({ roomId, senderId }: { roomId: string; senderId: stri
   };
 
   return (
-    <div className="flex gap-2 p-2">
+    <div className={inputContainerStyles}>
       <input
         value={message}
         onChange={(e) => setMessage(e.target.value)}
         onKeyDown={handleKeyDown}
-        className="flex-1 rounded-md border border-gray-300 px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-purple-400"
+        className={inputStyles}
         placeholder="메시지를 입력하세요"
       />
       <button
         onClick={handleSend}
         disabled={mutation.isPending}
-        className="rounded-md bg-purple-500 px-4 py-2 text-sm text-white hover:bg-purple-600 active:bg-purple-700 disabled:bg-gray-300"
+        className={cn(
+          buttonStyles.base,
+          buttonStyles.bg,
+          buttonStyles.text,
+          buttonStyles.hoverBg,
+          buttonStyles.activeBg,
+          buttonStyles.disabledBg
+        )}
       >
         {mutation.isPending ? '전송 중...' : '전송'}
       </button>

--- a/apps/web/features/chat-room/ui/ChatMessages.tsx
+++ b/apps/web/features/chat-room/ui/ChatMessages.tsx
@@ -3,11 +3,20 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { Avatar } from '@repo/ui/design-system/base-components/Avatar/index';
+import { cn } from '@repo/ui/utils/cn';
 
 import { useMessages } from '@/hooks/chat/useMessages';
 import { useMessagesAsRead } from '@/hooks/chat/useMessagesAsRead';
 import { subscribeToMessages } from '@/hooks/chat/useMessageSubscription';
 import { Message, MessageWithSender } from '@/types/chat';
+
+import {
+  containerStyles,
+  messageBubbleStyles,
+  messageRowStyles,
+  timestampStyles,
+  unreadIndicatorStyles,
+} from './styles/ChatMessages.styles';
 
 export const ChatMessages = ({
   roomId,
@@ -90,14 +99,17 @@ export const ChatMessages = ({
   }, [messages, currentUserId]);
 
   return (
-    <div className="flex flex-col gap-3 px-4 py-3">
+    <div className={containerStyles}>
       {messages.map((msg) => {
         const isMine = msg.sender_id === currentUserId;
 
         return (
           <div
             key={msg.message_id}
-            className={`flex items-end ${isMine ? 'justify-end' : 'justify-start'}`}
+            className={cn(
+              messageRowStyles.base,
+              isMine ? messageRowStyles.mine : messageRowStyles.theirs
+            )}
           >
             {!isMine && (
               <Avatar
@@ -110,17 +122,17 @@ export const ChatMessages = ({
             )}
 
             <div
-              className={`relative max-w-[70%] rounded-xl px-4 py-2 text-sm leading-tight shadow-sm ${
-                isMine
-                  ? 'rounded-br-none bg-[#BEAFFC] text-white'
-                  : 'rounded-bl-none bg-gray-200 text-black'
-              }`}
+              className={cn(
+                messageBubbleStyles.base,
+                isMine ? messageBubbleStyles.mine : messageBubbleStyles.theirs
+              )}
             >
               {msg.content}
               <div
-                className={`mt-1 text-[10px] ${
-                  isMine ? 'text-right text-white' : 'text-right text-gray-500'
-                }`}
+                className={cn(
+                  timestampStyles.base,
+                  isMine ? timestampStyles.mine : timestampStyles.theirs
+                )}
               >
                 {new Date(msg.sent_at).toLocaleTimeString('ko-KR', {
                   hour: '2-digit',
@@ -128,9 +140,7 @@ export const ChatMessages = ({
                 })}
               </div>
 
-              {isMine && !msg.is_read && (
-                <div className="absolute -right-4 bottom-0 text-[18px] text-red-500">1</div>
-              )}
+              {isMine && !msg.is_read && <div className={unreadIndicatorStyles}>1</div>}
             </div>
 
             {isMine && (

--- a/apps/web/features/chat-room/ui/styles/ChatInput.styles.ts
+++ b/apps/web/features/chat-room/ui/styles/ChatInput.styles.ts
@@ -1,0 +1,13 @@
+export const inputContainerStyles = 'flex gap-2 p-2';
+
+export const inputStyles =
+  'flex-1 rounded-md border border-[var(--form-border)] px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-primary-400)]';
+
+export const buttonStyles = {
+  base: 'rounded-md px-4 py-2 text-sm',
+  bg: 'bg-[var(--button-primary-bg)]',
+  text: 'text-[var(--button-primary-text)]',
+  hoverBg: 'hover:bg-[var(--button-primary-bg-hover)]',
+  activeBg: 'active:bg-[var(--button-primary-bg-active)]',
+  disabledBg: 'disabled:bg-[var(--button-disabled-bg)]',
+};

--- a/apps/web/features/chat-room/ui/styles/ChatMessages.styles.ts
+++ b/apps/web/features/chat-room/ui/styles/ChatMessages.styles.ts
@@ -1,0 +1,21 @@
+export const containerStyles = 'flex flex-col gap-3 px-4 py-3';
+
+export const messageRowStyles = {
+  base: 'flex items-end',
+  mine: 'justify-end',
+  theirs: 'justify-start',
+};
+
+export const messageBubbleStyles = {
+  base: 'relative max-w-[70%] rounded-xl px-4 py-2 text-sm leading-tight shadow-sm',
+  mine: 'rounded-br-none bg-[var(--button-secondary-bg)] text-[var(--button-primary-text)]',
+  theirs: 'rounded-bl-none bg-[var(--bg-disabled)] text-[var(--text-primary)]',
+};
+
+export const timestampStyles = {
+  base: 'mt-1 text-[10px] text-right',
+  mine: 'text-[var(--button-primary-text)]',
+  theirs: 'text-[var(--text-tertiary)]',
+};
+
+export const unreadIndicatorStyles = 'absolute -right-4 bottom-0 text-[18px] text-[var(--text-error)]';


### PR DESCRIPTION
## 📋 작업 내용
package의 theme.css 를 참조하였습니다.
chat page 관련 컴포넌트들을 다른 파일로 상수화 하였습니다.

## 🔧 변경 사항
- chat 관련 features 폴더의 UI들을 styles 폴더에 상수화 하였습니다.
