### PR TITLE
Fix/profile avatar hydration #110

### DIFF
--- a/apps/web/features/profile/ui/ProfileAvatarUpload.tsx
+++ b/apps/web/features/profile/ui/ProfileAvatarUpload.tsx
@@ -29,13 +29,12 @@ export const ProfileAvatarUpload = ({
       // 선택된 파일을 상위 컴포넌트(ProfileForm)로 전달합니다.
       // 상위 컴포넌트가 이 파일을 가지고 미리보기 URL을 생성하고 상태를 업데이트
       onFileSelect(file);
-    } else {
-      // 파일 선택 취소 시
-      // 파일이 선택되지 않았음을 상위 컴포넌트(ProfileForm)로 전달.
-      // 상위 컴포넌트가 이 정보를 가지고 미리보기 URL을 기존(DB) 아바타로 되돌림.
-      onFileSelect(undefined);
     }
   };
+
+  if (!avatarUrl) {
+    return <div>loading...</div>;
+  }
 
   return (
     <div className="flex justify-center">

--- a/apps/web/widgets/profile/ui/ProfileForm.tsx
+++ b/apps/web/widgets/profile/ui/ProfileForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { Button } from '@repo/ui/design-system/base-components/Button/index';
 import { Input } from '@repo/ui/design-system/base-components/Input/index';
@@ -14,11 +14,10 @@ import { getCacheBustingUrl } from '@/lib/utils/avatar';
 import { ProfileFormType, UserProfileType } from '@/types/profile';
 
 export const ProfileForm = ({ user }: { user: UserProfileType }) => {
+  // 1. 초기 상태는 user.avatar의 순수한 URL로 설정.
+  // 이 값이 서버에서 렌더링되어 HTML에 포함.
+  const [avatarPreviewUrl, setAvatarPreviewUrl] = useState<string | undefined>(undefined);
   const [selectedFile, setSelectedFile] = useState<File | undefined>(undefined);
-  const [avatarPreviewUrl, setAvatarPreviewUrl] = useState<string | undefined>(
-    getCacheBustingUrl(user.avatar)
-  );
-
   const [enteredValues, setEnteredValues] = useState<ProfileFormType>({
     username: user.username,
     address: user.address,
@@ -29,14 +28,24 @@ export const ProfileForm = ({ user }: { user: UserProfileType }) => {
     undefined
   );
 
+  // 2. useEffect를 사용하여 컴포넌트가 클라이언트에서 마운트(하이드레이션)된 후에
+  // 캐시 버스터가 적용된 URL로 상태를 업데이트
+  useEffect(() => {
+    // selectedFile이 없고, user.avatar가 존재할 때만 캐시 버스팅을 적용
+    // 이는 사용자가 새 파일을 선택하기 전의 기본 아바타에만 해당
+    if (!selectedFile && user.avatar) {
+      setAvatarPreviewUrl(getCacheBustingUrl(user.avatar));
+    }
+
+    // user.avatar가 변경될 때 (예: 프로필 업데이트 후 데이터 리프레시), 이 effect를 다시 실행
+  }, [selectedFile, user.avatar]);
+
   const handleFileSelect = (file: File | undefined) => {
     setSelectedFile(file);
+
     if (file) {
-      // 파일이 선택되면  미리보기 URL을 생성하고 ProfileForm의 상태를 업데이트합니다.
+      // 파일이 선택되면 미리보기 URL을 생성하고 ProfileForm의 상태를 업데이트합니다.
       setAvatarPreviewUrl(URL.createObjectURL(file));
-    } else {
-      // 파일 선택이 취소되면 여기서 기존 DB URL로 ProfileForm의 상태를 복원합니다.
-      setAvatarPreviewUrl(getCacheBustingUrl(user.avatar));
     }
   };
 


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용
스토리지에 유저 아바타 이미지 업로드 작업을 파일명을 고정하여 기존 파일에 덮어쓰는 방식으로 하였습니다. 
그런데 이미지 파일명이 같아서 브라우저 캐시로 인해 변경 전 이미지가 나타나는 문제가 발생했고, 
이 문제를 해결하기 위해 이미지 파일명 뒤에 `Date.now() `함수를 이용해 ? 쿼리 파라미터를 붙여 브라우저에게 이미지 파일이 바뀌었으니 새로 요청하게 했습니다.

### 문제 원인
```typescript
A tree hydrated but some attributes of the server rendered HTML didn't match the client properties. This won't be patched up. This can happen if a SSR-ed Client Component used:

- A server/client branch `if (typeof window !== 'undefined')`.

- Variable input such as `Date.now()` or `Math.random()` which changes each time it's called.

- Date formatting in a user's locale which doesn't match the server.

- Exter- A server/client branch `if (typeof window !== 'undefined')`.

- Variable input such as `Date.now()` or `Math.random()` which changes each time it's called.

- Date formatting in a user's locale which doesn't match the server.

- External changing data without sending a snapshot of it along with the HTML.

- Invalid HTML tag nesting.

It can also happen if the client has a browser extension installed which messes with the HTML before React loaded.

```
`Date.now`와 같이 변동성이 있는 값을 서버와 클라이언트에서 다르게 생성하여 `ProfileForm` 컴포넌트의 초기 렌더링 결과가 불일치 하기 때문에 발생한 문제였습니다. 

**서버 사이드 렌더링**: 사용자가 다른 페이지에서 '/profile/update' 경로로 직접 접근하거나(직접 주소치기, 외부 링크, ..) 새로고침하면, Next.js는 해당 페이지를 서버에서 렌더링 합니다. 
 브라우저가 해당 URL로 Next.js 서버에 요청을 보냄 -> 초기 HTML 생성 후 클라이언트(브라우저)로 전송 -> React가 이 HTML 과 JS 코드와 연결(하이드레이션) 시도

기존 `profileForm.tsx`는 user prop을 받아 `avatarPreviewUrl`상태를 `getCacheBustingUrl`로 상태를 초기화 합니다. 이때 서버의 현재 시간을 기준으로 특정 타임스탬프를 생성합니다.  `https://.../avatar.jpg?t=T1`

**클라이언트 사이드 하이드레이션**:
ProfileForm.tsx (클라이언트 컴포넌트)가 클라이언트에서 다시 렌더링을 시도하면서 avatarPreviewUrl 상태를 다시 초기화합니다.
`getCacheBustingUrl`가 클라이언트에서 다시 호출되고, Date.now()는 서버에서 호출된 시간보다 약간 뒤의 다른 타임스탬프를 생성합니다.
이때 불일치가 발생하는 것이었습니다.
=> SSR 과정에서 ProfileForm과 같은 클라이언트 컴포넌트 내부에 Date.now와 같은 변동성 있는 값이 사용되었기 때문 
=> ProfileForm처럼 useState를 사용하여 클라이언트에서 초기 상태를 재구성하는 클라이언트 컴포넌트에서 발생하는 에러! 

`next/link`나 `router.push()`를 통해 페이지 내부에서 이동할 때는 전체 페이지를 SSR 하지 않고, 필요한 데이터만 가져와 클라이언트에서 컴포넌트를 렌더링합니다. 이 경우 `Date.now()`는 오직 클라이언트에서만 호출되므로 서버-클라이언트 간의 불일치가 발생하지 않습니다.


### 해결 
서버에서 렌더링될 때는 캐시 버스터가 없는 순수한 URL 또는 undefined로 초기화하고, 클라이언트에서 하이드레이션이 완료된 후에만 캐시 버스터를 적용 useEffect 적용 

**기존**
```
ProfileForm.tsx
const [avatarPreviewUrl, setAvatarPreviewUrl] = useState<string | undefined>(getCacheBustingUrl(user.avatar)); // 변동성이 있는 값을 초기 값으로 설정
```

**변경** 
```typescript
export const ProfileForm = ({ user }: { user: UserProfileType }) => {
  // 1. 초기 상태는 user.avatar의 순수한 URL 또는 undefined로 설정합니다.
  // 이 값이 서버에서 렌더링되어 HTML에 포함됩니다.
  const [avatarPreviewUrl, setAvatarPreviewUrl] = useState<string | undefined>(undefined);

  // 2. useEffect를 사용하여 컴포넌트가 클라이언트에서 마운트(하이드레이션)된 후에
  // 캐시 버스터가 적용된 URL로 상태를 업데이트합니다.
  useEffect(() => {
    // selectedFile이 없고, user.avatar가 존재할 때만 캐시 버스팅을 적용합니다.
    // 이는 사용자가 새 파일을 선택하기 전의 기본 아바타에만 해당됩니다.
    if (!selectedFile && user.avatar) {
      setAvatarPreviewUrl(getCacheBustingUrl(user.avatar));
    }
  }, [user.avatar, selectedFile]); 


 return (
    <ProfileAvatarUpload
      avatarUrl={avatarPreviewUrl} // 현재 표시할 URL (Blob이거나 DB URL + 캐시 버스터)
      onFileSelect={handleFileSelect}
    />
  );

```

## 🔧 변경 사항

## 📸 스크린샷 (선택 사항)

## 📄 기타
