### PR TITLE
fix: vercel 베포 - 오류 해결 (#128)

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -14,8 +14,8 @@
   },
   "license": "MIT",
   "scripts": {
-    "build": "build:styles && build:components",
-    "build:styles": "tailwindcss -i ./src/styles.css -o ./dist/index.css",
+    "build": "pnpm run build:styles && pnpm run build:components",
+    "build:styles": "tailwindcss -c ./tailwind.config.ts -i ./src/styles.css -o ./dist/index.css",
     "build:components": "tsc",
     "check-types": "tsc --noEmit",
     "dev:styles": "tailwindcss -i ./src/styles.css -o ./dist/index.css --watch",

--- a/packages/ui/tailwind.config.ts
+++ b/packages/ui/tailwind.config.ts
@@ -1,0 +1,10 @@
+import type { Config } from 'tailwindcss'
+
+const config: Config = {
+  content: ['./src/**/*.{ts,tsx}'], // 꼭 넣어야 Tailwind가 사용 클래스 인식함
+  theme: {
+    extend: {}
+  },
+  plugins: []
+}
+export default config

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,12 @@
 {
   "$schema": "https://turborepo.com/schema.json",
   "ui": "tui",
+  "globalEnv": [
+    "NEXT_PUBLIC_SUPABASE_URL",
+    "NEXT_PUBLIC_SUPABASE_ANON_KEY",
+    "SUPABASE_SERVICE_ROLE_KEY",
+    "NEXT_PUBLIC_BASE_URL"
+  ],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "buildCommand": "turbo run build --filter=!@apps/docs",
+  "outputDirectory": ".next"
+}


### PR DESCRIPTION
## 📋 작업 내용
- vercel 베포시 겪은 오류들 해결


## 🔧 변경 사항
- 1. Module Not Found: @repo/ui/styles
원인:
@repo/ui/styles가 dist/index.css를 참조하는데, 해당 파일이 없거나 빌드 전이었음.

해결 방법:
![스크린샷 2025-07-03 163048](https://github.com/user-attachments/assets/36e0e9df-3802-496a-ace0-e45f4358c71f)




- 2. tailwind.config.js 없음
원인:
Tailwind는 기본적으로 tailwind.config.js를 참조함. 없을 경우 일부 기능 동작 불능.

해결 방법:

packages/tailwind-config에 tailwind.config.ts 작성

packages/ui/tailwind.config.ts에서 위 설정을 extend
![스크린샷 2025-07-03 163232](https://github.com/user-attachments/assets/06a195bf-da51-4a2c-b6e3-387c427e53c8)
![스크린샷 2025-07-03 163239](https://github.com/user-attachments/assets/bbbfe1c4-9202-4486-999a-6ce77d5f83e0)




-3. 환경변수(SUPABASE_SERVICE_ROLE_KEY) undefined로 인한 빌드 실패
원인:
Supabase adminClient가 모듈 최상단에서 process.env를 읽었지만,
Vercel 빌드 시 해당 환경변수가 누락됨.

해결 방법:

turbo.json에 globalEnv 추가:
![스크린샷 2025-07-03 163349](https://github.com/user-attachments/assets/8d02f26b-1340-4773-90ad-1d538c63dc02)
이를 통해 모든 workspace에 빌드 시 환경변수가 주입됨




4. routes-manifest.json not found
원인:
vercel.json에 "outputDirectory": "apps/web/.next" 설정 →
Vercel 내부 경로가 /apps/web/apps/web/.next처럼 중첩됨

해결 방법:

vercel.json에서 "outputDirectory": ".next"로 수정
(Vercel은 apps/web 안에서 build command를 실행하므로 상대 경로 기준)
![스크린샷 2025-07-03 163516](https://github.com/user-attachments/assets/bc981bae-ab1d-46c8-a2a9-8ee3aa13a13d)