### PR TITLE
fix:eslint-config 파일 -   "./next": "./next.js" 추가

### DIFF
--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -6,6 +6,7 @@
   "exports": {
     "./base": "./base.js",
     "./next-js": "./next.js",
+    "./next": "./next.js",
     "./react-internal": "./react-internal.js"
   },
   "devDependencies": {


### PR DESCRIPTION
## 📋 작업 내용
- 커널 레포에서 dev -> main 병합 시 CI 오류 발생

Package subpath './next' is not defined by "exports"

apps/docs에서 @repo/eslint-config/next 를 import하려 하고 있는 것
그러나 "./next"는 exports에 정의되어 있지 않기 때문에 실패

## 🔧 변경 사항
![스크린샷 2025-07-03 173749](https://github.com/user-attachments/assets/63127490-b456-4723-9e72-37651a0d888a)

eslint-config의 package.json 파일 변경



