### PR TITLE
[refactor]: 경매 등록 페이지 구조 리펙토링

### DIFF
--- a/apps/web/app/(main)/auction/auction-add/page.tsx
+++ b/apps/web/app/(main)/auction/auction-add/page.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import { useState } from 'react';
-
 import { Button } from '@repo/ui/design-system/base-components/Button/index';
 import { Input } from '@repo/ui/design-system/base-components/Input/index';
 import { LocationInfo } from '@repo/ui/design-system/base-components/LocationInfo/index';
@@ -16,147 +14,99 @@ import {
 } from '@/features/auction-add/model/handlers';
 import { AuctionDateSelector } from '@/features/auction-add/ui/AuctionDateSelector';
 import { AuctionImageUploader } from '@/features/auction-add/ui/AuctionImageUploader';
+import { ErrorMessage } from '@/features/auction-add/ui/ErrorMessage';
 import { ProductDescriptionInput } from '@/features/auction-add/ui/ProductDescriptionInput';
 
-import { useCreateAuction } from '@/hooks/useCreateAuction';
-import { auctionAddSchema } from '@/lib/validators/auctionAddSchema';
+import { useAuctionAddForm } from '@/features/auction-add/model/useAuctionAddForm';
 import { categories } from '@/mock/auction';
-import { useAuthStore } from '@/stores/auth';
 
 const Page = () => {
-  const getToday = (): string => {
-    const today = new Date();
-    return today.toISOString().split('T')[0] as string;
-  };
-  const [auctionName, setAuctionName] = useState('');
-  const [startPrice, setStartPrice] = useState('');
-  const [auctionCategory, setAuctionCategory] = useState('');
-  const [auctionDescription, setAuctionDescription] = useState('');
-  const [images, setImages] = useState<string[]>([]);
-  const [startDate, setStartDate] = useState<string>(getToday());
-  const [endDate, setEndDate] = useState<string>(getToday());
-  const [, setFormError] = useState<string | null>(null);
-  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
-
-  const createAuctionMutation = useCreateAuction();
-
-  const sellerId = useAuthStore((state) => state.userId);
-
-  // 등록 버튼 클릭 시 유효성 검사 및 서버 전송
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setFormError(null);
-    setFieldErrors({});
-    const result = auctionAddSchema.safeParse({
-      images, // string[] (url)
-      auctionName,
-      auctionCategory,
-      startPrice,
-      auctionDescription,
-      startDate,
-      endDate,
-    });
-    if (!result.success) {
-      // 각 필드별 에러 메시지 추출
-      const errors: Record<string, string> = {};
-      result.error.errors.forEach((err) => {
-        if (err.path[0]) errors[err.path[0]] = err.message;
-      });
-      setFieldErrors(errors);
-      setFormError(result.error.errors[0]?.message || '입력값을 확인해 주세요.');
-      return;
-    }
-    // 서버 전송 로직 (react-query mutation)
-    const payload = {
-      seller_id: sellerId,
-      name: auctionName,
-      category: auctionCategory,
-      description: auctionDescription,
-      start_price: Number(startPrice),
-      start_time: startDate,
-      end_time: endDate,
-      thumbnail: images[0] || '',
-      images: images, // string[] (url 배열)
-    };
-    createAuctionMutation.mutate(payload);
-  };
+  const {
+    auctionName,
+    setAuctionName,
+    startPrice,
+    setStartPrice,
+    auctionCategory,
+    setAuctionCategory,
+    auctionDescription,
+    setAuctionDescription,
+    images,
+    setImages,
+    startDate,
+    setStartDate,
+    endDate,
+    setEndDate,
+    fieldErrors,
+    setFieldErrors,
+    handleSubmit,
+  } = useAuctionAddForm();
 
   return (
-    <form onSubmit={handleSubmit}>
+    <form onSubmit={handleSubmit} className="flex w-full max-w-md flex-col gap-4">
       {/*사진 등록 및 위치*/}
-      <AuctionImageUploader images={images} setImages={setImages} />
-      {fieldErrors.images && (
-        <div className="my-1 ml-1 text-xs text-red-500">{fieldErrors.images}</div>
-      )}
-      <LocationInfo address="서울시 강남구" />
+      <fieldset>
+        <AuctionImageUploader images={images} setImages={setImages} />
+        <ErrorMessage message={fieldErrors.images} />
+        <LocationInfo address="서울시 강남구" />
+      </fieldset>
+
       {/*경매 정보 입력*/}
-      <section className="mt-4 flex w-full max-w-md flex-col gap-4">
-        <div className="flex flex-col">
-          <Input
-            label="경매 이름"
-            value={auctionName}
-            onChange={(e) => handleInputChange(e, setAuctionName, 'auctionName', setFieldErrors)}
-          />
-          {fieldErrors.auctionName && (
-            <div className="my-1 ml-1 text-xs text-red-500">{fieldErrors.auctionName}</div>
-          )}
-        </div>
-        <div className="flex flex-col">
-          <Select
-            label="경매 카테고리"
-            value={auctionCategory}
-            onChange={(e) =>
-              handleSelectChange(e, setAuctionCategory, 'auctionCategory', setFieldErrors)
-            }
-            options={categories.map((c: { title: string }) => c.title)}
-            id="auctionCategory"
-          />
-          {fieldErrors.auctionCategory && (
-            <div className="my-1 ml-1 text-xs text-red-500">{fieldErrors.auctionCategory}</div>
-          )}
-        </div>
-        <div className="flex flex-col">
-          <Input
-            label="경매 시작가"
-            value={startPrice}
-            onChange={(e) => handleStartPriceInput(e, setStartPrice, setFieldErrors)}
-          />
-          {fieldErrors.startPrice && (
-            <div className="my-1 ml-1 text-xs text-red-500">{fieldErrors.startPrice}</div>
-          )}
-        </div>
-        {/* 날짜 선택 컴포넌트 */}
-        <div className="flex flex-col">
-          <AuctionDateSelector
-            startDate={startDate}
-            endDate={endDate}
-            setStartDate={(date) =>
-              handleDateChange(date, setStartDate, 'startDate', setFieldErrors)
-            }
-            setEndDate={(date) => handleDateChange(date, setEndDate, 'endDate', setFieldErrors)}
-          />
-          {(fieldErrors.startDate || fieldErrors.endDate) && (
-            <div className="my-1 ml-1 text-xs text-red-500">
-              {fieldErrors.startDate || fieldErrors.endDate}
-            </div>
-          )}
-        </div>
-        {/* 상품 정보 입력 */}
-        <div className="flex flex-col">
-          <ProductDescriptionInput
-            value={auctionDescription}
-            onChange={(e) =>
-              handleTextareaChange(e, setAuctionDescription, 'auctionDescription', setFieldErrors)
-            }
-          />
-          {fieldErrors.auctionDescription && (
-            <div className="my-1 ml-1 text-xs text-red-500">{fieldErrors.auctionDescription}</div>
-          )}
-        </div>
-        <Button variants="primary" type="submit">
-          경매 등록
-        </Button>
-      </section>
+      <fieldset>
+        <Input
+          label="경매 이름"
+          value={auctionName}
+          onChange={(e) => handleInputChange(e, setAuctionName, 'auctionName', setFieldErrors)}
+        />
+        <ErrorMessage message={fieldErrors.auctionName} />
+      </fieldset>
+
+      <fieldset>
+        <Select
+          label="경매 카테고리"
+          value={auctionCategory}
+          onChange={(e) =>
+            handleSelectChange(e, setAuctionCategory, 'auctionCategory', setFieldErrors)
+          }
+          options={categories.map((c: { title: string }) => c.title)}
+          id="auctionCategory"
+        />
+        <ErrorMessage message={fieldErrors.auctionCategory} />
+      </fieldset>
+
+      <fieldset>
+        <Input
+          label="경매 시작가"
+          value={startPrice}
+          onChange={(e) => handleStartPriceInput(e, setStartPrice, setFieldErrors)}
+        />
+        <ErrorMessage message={fieldErrors.startPrice} />
+      </fieldset>
+
+      {/* 날짜 선택 컴포넌트 */}
+      <fieldset>
+        <AuctionDateSelector
+          startDate={startDate}
+          endDate={endDate}
+          setStartDate={(date) => handleDateChange(date, setStartDate, 'startDate', setFieldErrors)}
+          setEndDate={(date) => handleDateChange(date, setEndDate, 'endDate', setFieldErrors)}
+        />
+        <ErrorMessage message={fieldErrors.startDate || fieldErrors.endDate} />
+      </fieldset>
+
+      {/* 상품 정보 입력 */}
+      <fieldset>
+        <ProductDescriptionInput
+          value={auctionDescription}
+          onChange={(e) =>
+            handleTextareaChange(e, setAuctionDescription, 'auctionDescription', setFieldErrors)
+          }
+        />
+        <ErrorMessage message={fieldErrors.auctionDescription} />
+      </fieldset>
+
+      <Button variants="primary" type="submit" size="thinLg">
+        경매 등록
+      </Button>
     </form>
   );
 };

--- a/apps/web/features/auction-add/model/useAuctionAddForm.ts
+++ b/apps/web/features/auction-add/model/useAuctionAddForm.ts
@@ -1,0 +1,77 @@
+import { useCreateAuction } from '@/hooks/useCreateAuction';
+import { auctionAddSchema } from '@/lib/validators/auctionAddSchema';
+import { useAuthStore } from '@/stores/auth';
+import { getToday } from '@repo/ui/utils/getToday';
+import { useState } from 'react';
+
+export function useAuctionAddForm() {
+  const [auctionName, setAuctionName] = useState('');
+  const [startPrice, setStartPrice] = useState('');
+  const [auctionCategory, setAuctionCategory] = useState('');
+  const [auctionDescription, setAuctionDescription] = useState('');
+  const [images, setImages] = useState<string[]>([]);
+  const [startDate, setStartDate] = useState<string>(getToday());
+  const [endDate, setEndDate] = useState<string>(getToday());
+  const [formError, setFormError] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+  const createAuctionMutation = useCreateAuction();
+  const sellerId = useAuthStore((state) => state.userId);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setFormError(null);
+    setFieldErrors({});
+    const result = auctionAddSchema.safeParse({
+      images,
+      auctionName,
+      auctionCategory,
+      startPrice,
+      auctionDescription,
+      startDate,
+      endDate,
+    });
+    if (!result.success) {
+      const errors: Record<string, string> = {};
+      result.error.errors.forEach((err) => {
+        if (err.path[0]) errors[err.path[0]] = err.message;
+      });
+      setFieldErrors(errors);
+      setFormError(result.error.errors[0]?.message || '입력값을 확인해 주세요.');
+      return;
+    }
+    const payload = {
+      seller_id: sellerId,
+      name: auctionName,
+      category: auctionCategory,
+      description: auctionDescription,
+      start_price: Number(startPrice),
+      start_time: startDate,
+      end_time: endDate,
+      thumbnail: images[0] || '',
+      images,
+    };
+    createAuctionMutation.mutate(payload);
+  };
+
+  return {
+    auctionName,
+    setAuctionName,
+    startPrice,
+    setStartPrice,
+    auctionCategory,
+    setAuctionCategory,
+    auctionDescription,
+    setAuctionDescription,
+    images,
+    setImages,
+    startDate,
+    setStartDate,
+    endDate,
+    setEndDate,
+    formError,
+    setFormError,
+    fieldErrors,
+    setFieldErrors,
+    handleSubmit,
+  };
+}

--- a/apps/web/features/auction-add/ui/AuctionDateSelector.tsx
+++ b/apps/web/features/auction-add/ui/AuctionDateSelector.tsx
@@ -1,16 +1,6 @@
 'use client';
 
-const getToday = () => {
-  const today = new Date();
-  return today.toISOString().split('T')[0];
-};
-
-const addDays = (dateStr: string, days: number): string => {
-  const date = new Date(dateStr);
-  date.setDate(date.getDate() + days);
-  return date.toISOString().split('T')[0] as string;
-};
-
+import { getToday } from '@repo/ui/utils/getToday';
 interface AuctionDateSelectorProps {
   startDate: string;
   endDate: string;
@@ -24,6 +14,12 @@ export const AuctionDateSelector = ({
   setStartDate,
   setEndDate,
 }: AuctionDateSelectorProps) => {
+  const addDays = (dateStr: string, days: number): string => {
+    const date = new Date(dateStr);
+    date.setDate(date.getDate() + days);
+    return date.toISOString().split('T')[0] as string;
+  };
+
   const today = getToday();
   // baseDate는 항상 string이 되도록 보장
   const baseDate = startDate;

--- a/apps/web/features/auction-add/ui/ErrorMessage.tsx
+++ b/apps/web/features/auction-add/ui/ErrorMessage.tsx
@@ -1,0 +1,4 @@
+export function ErrorMessage({ message }: { message?: string }) {
+  if (!message) return null;
+  return <div className="my-1 ml-1 text-xs text-red-500">{message}</div>;
+}

--- a/packages/ui/src/utils/getToday.ts
+++ b/packages/ui/src/utils/getToday.ts
@@ -1,0 +1,4 @@
+export const getToday = (): string => {
+  const today = new Date();
+  return today.toISOString().split('T')[0] as string;
+};


### PR DESCRIPTION
…ormessage 컴포넌트 분리

# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #132  -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용
경매 등록페이지를 리펙토링 했습니다.
## 🔧 변경 사항
state 및 submit 로직 form hook으로 분리
getToday함수 util함수로 분리
중복되는 errorMessage 코드 컴포넌트로 분리
div 태그를 fieldset 태그로 교체
Button 컴포넌트의 size 값이 누락되어있어 size 값 추가

## 📸 스크린샷 (선택 사항)

## 📄 기타
