### PR TITLE
feat: CI 검사 실패- docs의 eslint.config.js 오류 (#137)

### DIFF
--- a/packages/eslint-config/base.js
+++ b/packages/eslint-config/base.js
@@ -9,7 +9,7 @@ import onlyWarn from 'eslint-plugin-only-warn';
  *
  * @type {import("eslint").Linter.Config}
  * */
-export const config = [
+const config = [
   js.configs.recommended,
   eslintConfigPrettier,
   ...tseslint.configs.recommended,
@@ -30,3 +30,5 @@ export const config = [
     ignores: ['dist/**'],
   },
 ];
+
+export default config;

--- a/packages/eslint-config/next.js
+++ b/packages/eslint-config/next.js
@@ -16,7 +16,7 @@ import importPlugin from 'eslint-plugin-import';
  *
  * @type {import("eslint").Linter.Config}
  * */
-export const nextJsConfig = [
+const nextJsConfig = [
   ...baseConfig,
   js.configs.recommended,
   eslintConfigPrettier,
@@ -166,3 +166,5 @@ export const nextJsConfig = [
     },
   },
 ];
+
+export default nextJsConfig;

--- a/packages/eslint-config/react-internal.js
+++ b/packages/eslint-config/react-internal.js
@@ -10,7 +10,7 @@ import { config as baseConfig } from './base.js';
  * A custom ESLint configuration for libraries that use React.
  *
  * @type {import("eslint").Linter.Config} */
-export const config = [
+const config = [
   ...baseConfig,
   js.configs.recommended,
   eslintConfigPrettier,
@@ -37,3 +37,5 @@ export const config = [
     },
   },
 ];
+
+export default config;


### PR DESCRIPTION
## 📋 작업 내용
- 문제: @repo/eslint-config/base에서 default export가 없는데,
import config from '@repo/eslint-config/base'처럼 default import를 시도했다는 것.

- 해결: 
// packages/eslint-config/base.js
const config = [ ... ];
export default config;
로 변경

next.js, react-internal.js 등 다른 설정 파일도 동일하게