### PR TITLE
fix: react-internal.js default import로 수정 #140

### DIFF
--- a/packages/eslint-config/react-internal.js
+++ b/packages/eslint-config/react-internal.js
@@ -4,7 +4,7 @@ import tseslint from 'typescript-eslint';
 import pluginReactHooks from 'eslint-plugin-react-hooks';
 import pluginReact from 'eslint-plugin-react';
 import globals from 'globals';
-import { config as baseConfig } from './base.js';
+import baseConfig from './base.js';
 
 /**
  * A custom ESLint configuration for libraries that use React.


### PR DESCRIPTION
## 📋 작업 내용
import 방식 수정
packages/eslint-config/react-internal.js

import { config as baseConfig } from './base.js'; // ❌ named import
->
import baseConfig from './base.js'; // ✅ default import로 수정
