### PR TITLE
fix: chat- 무한 루프 오류 (#117)

### DIFF
--- a/apps/web/hooks/chat/useMessageSubscription.ts
+++ b/apps/web/hooks/chat/useMessageSubscription.ts
@@ -4,38 +4,32 @@ import { Message } from '@/types/chat';
 type Props = {
   roomId: string;
   onMessageInsert: (message: Message) => void;
-  onMessageUpdate?: (message: Message) => void;
+  onMessageUpdate: (message: Message) => void;
 };
 
 export const subscribeToMessages = ({ roomId, onMessageInsert, onMessageUpdate }: Props) => {
-  console.log('[subscribeToMessages] Setting up realtime for room:', roomId);
-
   const channel = supabase
-    .channel(`chat-${roomId}`)
+    .channel(`room:${roomId}`)
     .on(
       'postgres_changes',
       { event: 'INSERT', schema: 'public', table: 'message', filter: `room_id=eq.${roomId}` },
       (payload) => {
-        console.log('[Realtime] INSERT payload:', payload);
-        const msg = payload.new as Message;
-        onMessageInsert(msg);
+        onMessageInsert(payload.new as Message);
       }
     )
     .on(
       'postgres_changes',
       { event: 'UPDATE', schema: 'public', table: 'message', filter: `room_id=eq.${roomId}` },
       (payload) => {
-        console.log('[Realtime] UPDATE payload:', payload);
-        const msg = payload.new as Message;
-        onMessageUpdate?.(msg);
+        onMessageUpdate(payload.new as Message);
       }
     )
     .subscribe((status) => {
       console.log('[subscribeToMessages] subscription status:', status);
     });
 
+  // 반드시 unsubscribe 반환
   return () => {
-    console.log('[subscribeToMessages] Removing channel for room:', roomId);
     supabase.removeChannel(channel);
   };
 };


### PR DESCRIPTION
## 📋 작업 내용
문제 상황

채팅 페이지에 처음 진입했을 때는 Supabase Realtime 구독이 정상적으로 작동하며 메시지도 잘 수신됨.

그러나 뒤로 갔다가 다시 해당 채팅방에 진입하면 Realtime WebSocket 연결이 끊기거나 메시지를 받지 못하는 현상 발생.

## 🔧 변경 사항

원인 분석

1. 처음 진입 시 동작 흐름

ChatMessages 컴포넌트가 마운트됨

useMessages를 통해 초기 메시지 데이터(data)를 fetch

data가 존재할 때 useEffect가 실행되어 subscribeToMessages() 함수 호출

Supabase Realtime 채널 생성 및 WebSocket 연결 → 정상 작동

2. 뒤로 갔다가 다시 들어올 때 동작 흐름

React의 App Router는 페이지를 완전히 새로 렌더링하는 것이 아니라 컴포넌트의 상태를 보존한 채로 부분적으로 업데이트

이때 ChatMessages가 언마운트 → 다시 마운트되면서 useEffect가 두 번 이상 실행되는 경우가 발생 (특히 개발 환경에서 React.StrictMode로 인해 더 명확하게 보임)

기존 WebSocket 연결이 완전히 닫히기 전에 새로운 구독 시도 → WebSocket is closed before the connection is established 에러 발생

Supabase에서는 동일한 채널 이름으로 중복 연결을 방지하기 때문에, 이전 연결이 닫히기 전 새로운 구독 요청이 충돌함

해결 방법

기존 WebSocket 구독을 명확히 해제한 후

딜레이를 주고 새로운 구독을 생성하여 안정적으로 연결되도록 함

## 📸 스크린샷 (선택 사항)
![스크린샷 2025-07-04 144313](https://github.com/user-attachments/assets/f203d1f1-181b-461c-a6ac-db46109968c4)

- 이 코드로 인해 비동기 적으로 진행되는 WebSocket 기반에 동기 적으로 닫힐 시간 명시
if (subscriptionRef.current) {
        subscriptionRef.current();
        subscriptionRef.current = null;

        // 💡 WebSocket 안정적으로 닫힐 시간 확보
        await new Promise((res) => setTimeout(res, 300));
      }

