### PR TITLE
fix:체팅 페이지- setTimeout 로직 변경 (#168)

### DIFF
--- a/apps/web/app/(main)/chat/[roomId]/page.tsx
+++ b/apps/web/app/(main)/chat/[roomId]/page.tsx
@@ -10,6 +10,7 @@ import { useAuthStore } from '@/shared/stores/auth';
 const ChatPage = () => {
   const { roomId } = useParams();
   const senderId = useAuthStore((state) => state.userId);
+  console.log(senderId);
 
   if (!senderId) {
     return <div>로그인이 필요합니다</div>;
@@ -28,7 +29,7 @@ const ChatPage = () => {
 
       {/* 인풋 */}
       <div className="w-full px-2 pb-[env(safe-area-inset-bottom)] pt-2">
-        <ChatInput roomId={roomId} senderId={senderId} />
+        <ChatInput roomId={roomId} senderId={senderId} senderName={'test'} />
       </div>
     </div>
   );

--- a/apps/web/features/chat-room/ui/ChatInput.tsx
+++ b/apps/web/features/chat-room/ui/ChatInput.tsx
@@ -1,26 +1,30 @@
 'use client';
 
-import { useState } from 'react';
-
 import { cn } from '@repo/ui/utils/cn';
+import { useState } from 'react';
 
 import { useSendMessage } from '@/shared/api/client/chat/useSendMessage';
 import { buttonStyles, inputContainerStyles, inputStyles } from './styles/ChatInput.styles';
 
-export const ChatInput = ({ roomId, senderId }: { roomId: string; senderId: string }) => {
-  const [message, setMessage] = useState('');
-  const mutation = useSendMessage();
+export const ChatInput = ({
+  roomId,
+  senderId,
+  senderName,
+}: {
+  roomId: string;
+  senderId: string;
+  senderName: string;
+}) => {
+  const [input, setInput] = useState('');
+
+  // ✅ senderName까지 넘겨서 useSendMessage 훅에서 optimistic 처리
+  const { mutate, isPending } = useSendMessage(roomId, { id: senderId, name: senderName });
 
   const handleSend = () => {
-    if (!message.trim()) return;
+    if (!input.trim()) return;
 
-    mutation.mutate(
-      { roomId, senderId, content: message },
-      {
-        onSuccess: () => setMessage(''),
-        onError: (err) => console.error('메시지 전송 실패:', err),
-      }
-    );
+    mutate({ roomId, senderId, content: input });
+    setInput('');
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -33,15 +37,15 @@ export const ChatInput = ({ roomId, senderId }: { roomId: string; senderId: stri
   return (
     <div className={inputContainerStyles}>
       <input
-        value={message}
-        onChange={(e) => setMessage(e.target.value)}
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
         onKeyDown={handleKeyDown}
         className={inputStyles}
         placeholder="메시지를 입력하세요"
       />
       <button
         onClick={handleSend}
-        disabled={mutation.isPending}
+        disabled={isPending}
         className={cn(
           buttonStyles.base,
           buttonStyles.bg,
@@ -51,7 +55,7 @@ export const ChatInput = ({ roomId, senderId }: { roomId: string; senderId: stri
           buttonStyles.disabledBg
         )}
       >
-        {mutation.isPending ? '전송 중...' : '전송'}
+        {isPending ? '전송 중...' : '전송'}
       </button>
     </div>
   );

--- a/apps/web/features/chat-room/ui/ChatMessages.tsx
+++ b/apps/web/features/chat-room/ui/ChatMessages.tsx
@@ -1,15 +1,15 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 
 import { Avatar } from '@repo/ui/design-system/base-components/Avatar/index';
 import { cn } from '@repo/ui/utils/cn';
 
-import { Message, MessageWithSender } from '@/shared/types/chat';
-
 import { useMessages } from '@/shared/api/client/chat/useMessages';
 import { useMessagesAsRead } from '@/shared/api/client/chat/useMessagesAsRead';
+import { useQueryClient } from '@tanstack/react-query';
 import { subscribeToMessages } from '../model/subscribeToMessages';
+
 import {
   containerStyles,
   messageBubbleStyles,
@@ -25,97 +25,43 @@ export const ChatMessages = ({
   roomId: string;
   currentUserId: string;
 }) => {
-  const [messages, setMessages] = useState<MessageWithSender[]>([]);
-  const { data } = useMessages(roomId);
+  const queryClient = useQueryClient();
+  const { data: messages } = useMessages(roomId);
   const { mutate: markAsRead } = useMessagesAsRead();
   const subscriptionRef = useRef<() => void | null>(null);
   const bottomRef = useRef<HTMLDivElement | null>(null);
 
-  // 최초 fetch된 메시지 세팅
-  useEffect(() => {
-    if (data) setMessages(data);
-  }, [data]);
-
+  // 최신 메세지를 볼 수 있게 스크롤 맨 아래로
   useEffect(() => {
     if (bottomRef.current) {
       bottomRef.current.scrollIntoView({ behavior: 'smooth' }); // 또는 'auto'로 즉시 이동
     }
   }, [messages]);
 
-  // onMessageInsert 콜백
-  const onMessageInsert = useCallback((msg: Message) => {
-    setMessages((prev) => {
-      const sender = prev.find((m) => m.sender_id === msg.sender_id);
-      if (!sender) {
-        console.warn('[onMessageInsert] sender info not found for', msg.sender_id);
-        return prev;
-      }
-
-      const fullMessage: MessageWithSender = {
-        ...msg,
-        sender_name: sender.sender_name,
-        sender_avatar: sender.sender_avatar,
-        sender_address: sender.sender_address,
-        sender_address_detail: sender.sender_address_detail,
-        sender_score: sender.sender_score,
-      };
-
-      return [...prev, fullMessage];
-    });
-  }, []);
-
-  // onMessageUpdate 콜백
-  const onMessageUpdate = useCallback((updatedMsg: Message) => {
-    setMessages((prev) =>
-      prev.map((msg) =>
-        msg.message_id === updatedMsg.message_id ? { ...msg, is_read: updatedMsg.is_read } : msg
-      )
-    );
-  }, []);
-
-  // ✅ 구독은 메시지가 한번 로드된 이후 roomId에만 의존하여 실행 (단, 구독 중복 방지)
+  // 구독 설정
   useEffect(() => {
-    if (!data || data.length === 0) return;
+    if (!roomId) return;
 
     let unsubscribe: (() => void) | null = null;
-    let isUnmounted = false;
 
-    const setupSubscription = async () => {
-      // 이전 구독이 있다면 제거 후 딜레이
-      if (subscriptionRef.current) {
-        subscriptionRef.current();
-        subscriptionRef.current = null;
-
-        // 💡 WebSocket 안정적으로 닫힐 시간 확보
-        await new Promise((res) => setTimeout(res, 300));
-      }
-
-      if (isUnmounted) return;
-
-      console.log('[ChatMessages] subscribing to realtime');
-      unsubscribe = subscribeToMessages({
+    const setup = async () => {
+      unsubscribe = await subscribeToMessages({
         roomId,
-        onMessageInsert: (msg) => {
-          console.log('[Realtime] INSERT received:', msg);
-          onMessageInsert(msg);
+        onMessageInsert: () => {
+          queryClient.invalidateQueries({ queryKey: ['messages', roomId] });
         },
-        onMessageUpdate: (msg) => {
-          console.log('[Realtime] UPDATE received:', msg);
-          onMessageUpdate(msg);
+        onMessageUpdate: () => {
+          queryClient.invalidateQueries({ queryKey: ['messages', roomId] });
         },
       });
-
-      subscriptionRef.current = unsubscribe;
     };
 
-    setupSubscription();
+    setup();
 
     return () => {
-      isUnmounted = true;
-      console.log('[ChatMessages] unsubscribing from realtime');
-      unsubscribe?.();
+      unsubscribe?.(); // ✅ 반드시 구독 해제 필요
     };
-  }, [roomId, onMessageInsert, onMessageUpdate, data]);
+  }, [roomId]);
 
   // 읽음 처리
   // useEffect(() => {
@@ -127,6 +73,8 @@ export const ChatMessages = ({
   //     markAsRead(unreadIds);
   //   }
   // }, [messages, currentUserId]);
+
+  if (!messages) return <div>Loading...</div>;
 
   return (
     <div className={containerStyles}>

--- a/apps/web/features/profile/ui/ProfileAvatarUpload.tsx
+++ b/apps/web/features/profile/ui/ProfileAvatarUpload.tsx
@@ -1,22 +1,24 @@
-'use client';
-
 import { useRef } from 'react';
 
 import { Avatar } from '@repo/ui/design-system/base-components/Avatar/index';
 import { FaCamera } from 'react-icons/fa6';
 
-import { profileAvatarUploadStyles as styles } from '../styles/profileAvatarUpload.styles';
+import { supabase } from '@/lib/supabase/supabase';
 
 interface AvatarUploadProps {
+  id: string;
   username: string;
-  avatarUrl?: string; // ProfileForm에서 관리하는 현재 미리보기 URL
-  onFileSelect: (file: File | undefined) => void; // 선택된 File 객체를 상위로 전달하는 콜백
+  prevUrl?: string;
+  avatarUrl?: string;
+  setAvatarUrl: (value: string | undefined) => void;
 }
 
 export const ProfileAvatarUpload = ({
+  id,
   username,
-  avatarUrl, // ProfileForm에서 이미 캐시 버스터가 붙어 전달된 URL 사용
-  onFileSelect,
+  prevUrl,
+  avatarUrl,
+  setAvatarUrl,
 }: AvatarUploadProps) => {
   const imageRef = useRef<HTMLInputElement>(null);
 
@@ -24,40 +26,45 @@ export const ProfileAvatarUpload = ({
     imageRef.current?.click();
   };
 
-  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleImageChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     e.preventDefault();
     if (e.target.files && e.target.files[0]) {
       const file = e.target.files[0];
-      // 선택된 파일을 상위 컴포넌트(ProfileForm)로 전달합니다.
-      // 상위 컴포넌트가 이 파일을 가지고 미리보기 URL을 생성하고 상태를 업데이트
-      onFileSelect(file);
+      const fileExt = file.name.split('.').pop();
+      const filePath = `${id}.${fileExt}`;
+
+      const { data, error: uploadError } = await supabase.storage
+        .from('avatars')
+        .upload(filePath, file, {
+          cacheControl: '3600',
+          upsert: true,
+        });
+
+      if (uploadError) {
+        throw uploadError;
+      }
+
+      const { data: urlData } = supabase.storage.from('avatars').getPublicUrl(data.path);
+      setAvatarUrl(urlData.publicUrl + '?t=' + Date.now()); // 쿼리 파라미터로 캐시 무력화
     }
   };
 
-  if (!avatarUrl) {
-    return <div>loading...</div>;
-  }
-
   return (
-    <div className={styles.container}>
-      <div className={styles.avatarWrapper}>
-        <input
-          ref={imageRef}
-          type="file"
-          accept="image/*"
-          className={styles.fileInput}
-          onChange={handleImageChange}
-          data-testid="file-input"
-        />
+    <div className="flex justify-center">
+      <div className="relative inline-flex">
+        <input ref={imageRef} type="file" accept="image/*" hidden onChange={handleImageChange} />
         <Avatar
-          src={avatarUrl}
+          src={avatarUrl || prevUrl}
           alt={username}
           name={username}
           size="xxl"
-          className={styles.avatar}
+          className="relative"
         />
-        <p onClick={imageClick} role="button" aria-label="camera" className={styles.cameraButton}>
-          <FaCamera className={styles.cameraIcon} />
+        <p
+          onClick={imageClick}
+          className="border-3 absolute -right-[7px] bottom-0 inline-block cursor-pointer rounded-full border-solid border-white bg-neutral-500 p-1"
+        >
+          <FaCamera className="size-3.5 text-white" />
         </p>
       </div>
     </div>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -25,6 +25,7 @@
     "react-dom": "^19.1.0",
     "react-icons": "5.5.0",
     "swiper": "^11.2.8",
+    "uuid": "^11.1.0",
     "zod": "^3.25.67",
     "zustand": "^5.0.5"
   },
@@ -39,6 +40,7 @@
     "@types/node": "^22.15.3",
     "@types/react": "^19.1.0",
     "@types/react-dom": "^19.1.1",
+    "@types/uuid": "^10.0.0",
     "@vitejs/plugin-react": "^4.6.0",
     "@vitest/coverage-v8": "^3.2.3",
     "autoprefixer": "^10.4.20",

--- a/apps/web/shared/api/client/chat/useSendMessage.ts
+++ b/apps/web/shared/api/client/chat/useSendMessage.ts
@@ -1,10 +1,62 @@
-// features/chat-room/model/useSendMessage.ts
-import { useMutation } from '@tanstack/react-query';
-
 import { sendMessage } from '@/shared/api/server/chat/sendMessage';
+import { MessageWithSender } from '@/shared/types/chat';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { v4 as uuidv4 } from 'uuid';
 
-export const useSendMessage = () => {
-  return useMutation({
+type Variables = {
+  roomId: string;
+  senderId: string;
+  content: string;
+};
+
+export const useSendMessage = (roomId: string, currentUser: { id: string; name: string }) => {
+  const queryClient = useQueryClient();
+
+  return useMutation<void, Error, Variables, { previousMessages: MessageWithSender[] }>({
     mutationFn: sendMessage,
+
+    // ✅ Optimistic Update 적용
+    onMutate: async (variables) => {
+      const { content, senderId } = variables;
+
+      await queryClient.cancelQueries({ queryKey: ['messages', roomId] });
+
+      const previousMessages =
+        queryClient.getQueryData<MessageWithSender[]>(['messages', roomId]) ?? [];
+
+      const fakeMessage: MessageWithSender = {
+        message_id: uuidv4(),
+        room_id: roomId,
+        sender_id: senderId,
+        content,
+        sent_at: new Date().toISOString(),
+        is_read: false,
+        created_at: new Date().toISOString(),
+
+        // UI에 필요한 최소 sender 정보
+        sender_name: currentUser.name,
+        sender_avatar: null,
+        sender_address: null,
+        sender_address_detail: null,
+        sender_score: null,
+      };
+
+      queryClient.setQueryData<MessageWithSender[]>(
+        ['messages', roomId],
+        [...previousMessages, fakeMessage]
+      );
+
+      return { previousMessages };
+    },
+
+    onError: (_err, _newMessage, context) => {
+      if (context?.previousMessages) {
+        queryClient.setQueryData(['messages', roomId], context.previousMessages);
+      }
+    },
+
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ['messages', roomId] });
+    },
   });
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,6 +204,9 @@ importers:
       swiper:
         specifier: ^11.2.8
         version: 11.2.8
+      uuid:
+        specifier: ^11.1.0
+        version: 11.1.0
       zod:
         specifier: ^3.25.67
         version: 3.25.67
@@ -241,6 +244,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.1.1
         version: 19.1.6(@types/react@19.1.7)
+      '@types/uuid':
+        specifier: ^10.0.0
+        version: 10.0.0
       '@vitejs/plugin-react':
         specifier: ^4.6.0
         version: 4.6.0(vite@6.3.5)
@@ -3794,6 +3800,10 @@ packages:
   /@types/trusted-types@2.0.7:
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
     dev: false
+
+  /@types/uuid@10.0.0:
+    resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
+    dev: true
 
   /@types/ws@8.18.1:
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
@@ -11384,6 +11394,11 @@ packages:
   /utila@0.4.0:
     resolution: {integrity: sha512-Z0DbgELS9/L/75wZbro8xAnT50pBVFQZ+hUEueGDU5FN51YSCYM+jdxsfCiHjwNP/4LCDD0i/graKpeBnOXKRA==}
     dev: true
+
+  /uuid@11.1.0:
+    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+    hasBin: true
+    dev: false
 
   /uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}


### PR DESCRIPTION
## 📋 작업 내용
- realtime 구조 변경
- 지금 구조
roomId 바뀔 때마다 useEffect에서: 이전 구독 제거 ->잠시 기다림 (setTimeout) -> 잠시 기다림 (setTimeout) -> 다시 구독

Supabase는 메시지 수신 + onMessageInsert 호출 → 로컬 상태를 수동으로 갱신

이 흐름은 복잡하고 WebSocket 충돌 위험이 다수 존재(지금 겪는 문제)


## 🔧 변경 사항
TanStack Query로 메시지를 관리
→ 메시지 목록을 React Query로 useQuery로 불러옴
→ 메시지 삽입 시 queryClient.invalidateQueries로 refetch 유도

Supabase Realtime은 단순히 알림 역할만
→ INSERT/UPDATE 이벤트 수신 시, React Query의 캐시를 invalidate 또는 직접 cache update

변경 후 
 Supabase Realtime이 변경 사항을 감지하여 클라이언트에 전파하고, 그 후 React Query가 메시지를 다시 불러오는 구조

문제:
- 이 방식은 전송 후 메시지가 3~4초 지연되어 표시되는 UX 문제를 발생
해결:
-Optimistic UI를 도입.
메시지를 전송하기 전에 미리 화면에 렌더링하고, 실패 시 롤백하는 방식으로 UX를 개선한다.

[추후 문서로 업로드 하겠습니다.]

