### PR TITLE
refactor: 경매 등록 스키마 수정 및 날짜 관련 로직 변경

### DIFF
--- a/apps/docs/stories/Card.stories.tsx
+++ b/apps/docs/stories/Card.stories.tsx
@@ -44,6 +44,10 @@ const meta = {
       control: { type: 'date' },
       description: '종료일(Date 또는 ISO 문자열)',
     },
+    startTime: {
+      control: { type: 'date' },
+      description: '시작일(Date 또는 ISO 문자열)',
+    },
   },
   args: {
     imageSrc: 'https://picsum.photos/300/200',
@@ -51,6 +55,7 @@ const meta = {
     locationName: '서울 강남구',
     badgeVariant: 'best',
     endTime: new Date(Date.now() + 1000 * 60 * 60 * 10 + 1000 * 60 * 30).toISOString(), // 10시간 30분 후
+    startTime: new Date(Date.now() - 1000 * 60 * 60 * 2).toISOString(), // 2시간 전 시작
   },
 } satisfies Meta<typeof Card>;
 
@@ -65,6 +70,19 @@ export const Default: Story = {
     locationName: '부산 해운대',
     badgeVariant: 'best',
     endTime: new Date(Date.now() + 1000 * 60 * 60 * 5 + 1000 * 60 * 10).toISOString(), // 5시간 10분 후
+    startTime: new Date(Date.now() - 1000 * 60 * 60 * 1).toISOString(), // 1시간 전 시작
+  },
+};
+
+// 📝 경매 시작 전 카드
+export const BeforeStart: Story = {
+  args: {
+    imageSrc: 'https://picsum.photos/300/200?random=5',
+    title: '경매 시작 전 상품',
+    locationName: '서울 강남구',
+    badgeVariant: undefined,
+    endTime: new Date(Date.now() + 1000 * 60 * 60 * 24).toISOString(), // 24시간 후 종료
+    startTime: new Date(Date.now() + 1000 * 60 * 60 * 2).toISOString(), // 2시간 후 시작
   },
 };
 
@@ -76,6 +94,7 @@ export const Urgent: Story = {
     locationName: '인천 송도',
     badgeVariant: 'urgent',
     endTime: new Date(Date.now() + 1000 * 60 * 60 * 1 + 1000 * 60 * 5).toISOString(), // 1시간 5분 후
+    startTime: new Date(Date.now() - 1000 * 60 * 60 * 3).toISOString(), // 3시간 전 시작
   },
 };
 

--- a/apps/web/app/(main)/auction/[auctionId]/auction-detail/page.tsx
+++ b/apps/web/app/(main)/auction/[auctionId]/auction-detail/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { getTimeLeftString } from '@repo/ui/utils/getTimeLeftString';
+import { isAuctionStarted } from '@/shared/lib/utils/isAuctionStarted';
 import { useParams } from 'next/navigation';
 
 import {
@@ -39,6 +40,7 @@ const Page = () => {
   const startBidCost = data.start_price;
   const remainingTime = getTimeLeftString({ endDate: data.end_time, startDate: data.start_time });
   const bidUnit = 5000; // 입찰 단위
+  const auctionStarted = isAuctionStarted(data.start_time);
 
   return (
     <main className="relative flex w-full flex-col items-center justify-center gap-2.5" role="main">
@@ -54,6 +56,7 @@ const Page = () => {
         isProgressing={data.status === 'in progress'}
         auctionId={auctionId}
         sellerId={data.seller_id}
+        isAuctionStarted={auctionStarted}
         onMinus={minusBidCost}
         onPlus={plusBidCost}
         onClick={sendBid}

--- a/apps/web/app/(main)/auction/[auctionId]/auction-detail/page.tsx
+++ b/apps/web/app/(main)/auction/[auctionId]/auction-detail/page.tsx
@@ -37,7 +37,7 @@ const Page = () => {
   const imageFiles = data.images || [];
   const auctionName = product.name;
   const startBidCost = data.start_price;
-  const remainingTime = getTimeLeftString(data.end_time);
+  const remainingTime = getTimeLeftString({ endDate: data.end_time, startDate: data.start_time });
   const bidUnit = 5000; // 입찰 단위
 
   return (

--- a/apps/web/features/auction-add/model/useAuctionForm.ts
+++ b/apps/web/features/auction-add/model/useAuctionForm.ts
@@ -1,6 +1,7 @@
 import { useCreateAuction } from '@/shared/api/client/auction/useCreateAuction';
 import { useUpdateAuction } from '@/shared/api/client/auction/useUpdateAuction';
 import { formatDateString } from '@/shared/lib/utils/formatDateString';
+import { isAuctionStarted } from '@/shared/lib/utils/isAuctionStarted';
 import { auctionAddSchema } from '@/shared/lib/validators/auctionAddSchema';
 import { useAuthStore } from '@/shared/stores/auth';
 import { AuctionDetail } from '@/shared/types/db';
@@ -29,6 +30,9 @@ export function useAuctionForm({
   const updateAuctionMutation = useUpdateAuction();
   const sellerId = useAuthStore((state) => state.userId);
 
+  const isStarted =
+    initialData && initialData.start_time ? isAuctionStarted(initialData.start_time) : false;
+
   useEffect(() => {
     if (isEdit && initialData) {
       setAuctionName(initialData.product?.name || '');
@@ -43,6 +47,19 @@ export function useAuctionForm({
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+
+    if (isEdit && isStarted) {
+      alert('경매가 시작되어 수정이 불가능합니다.');
+      return;
+    }
+
+    const confirmMessage = isEdit
+      ? '경매 시작 이후로는 수정 및 삭제가 불가능하며\n당일 시작일 경우 10분의 유예시간이 주어집니다.\n경매를 수정하시겠습니까?'
+      : '경매 시작 이후로는 수정 및 삭제가 불가능하며\n당일 시작일 경우 10분의 유예시간이 주어집니다.\n경매를 등록하시겠습니까?';
+    if (!window.confirm(confirmMessage)) {
+      return; // 사용자가 취소를 누르면 함수 종료
+    }
+
     setFormError(null);
     setFieldErrors({});
 

--- a/apps/web/features/auction-add/model/useAuctionForm.ts
+++ b/apps/web/features/auction-add/model/useAuctionForm.ts
@@ -66,6 +66,23 @@ export function useAuctionForm({
       return;
     }
 
+    let finalStartDate = startDate;
+    let finalEndDate = endDate;
+
+    const today = new Date();
+    const todayDateString = today.toISOString().split('T')[0];
+
+    if (startDate.split('T')[0] === todayDateString) {
+      const now = new Date();
+      now.setMinutes(now.getMinutes() + 10);
+
+      finalStartDate = now.toISOString();
+
+      const endDateObj = new Date(endDate);
+      endDateObj.setHours(now.getHours(), now.getMinutes(), now.getSeconds());
+      finalEndDate = endDateObj.toISOString();
+    }
+
     if (isEdit) {
       if (sellerId !== initialData?.seller_id) {
         return alert('본인이 등록한 경매만 수정할 수 있습니다.');
@@ -82,8 +99,8 @@ export function useAuctionForm({
         auctionCategory: auctionCategory,
         auctionDescription: auctionDescription,
         images: images,
-        startDate: startDate,
-        endDate: endDate,
+        startDate: finalStartDate,
+        endDate: finalEndDate,
       };
 
       // 초기 데이터에서 수정 가능한 필드 값들을 객체로 구성
@@ -106,8 +123,8 @@ export function useAuctionForm({
       const completeAuctionData = {
         ...initialData,
         start_price: Number(startPrice),
-        start_time: startDate,
-        end_time: endDate,
+        start_time: finalStartDate,
+        end_time: finalEndDate,
         images: images,
         thumbnail: images[0] || '',
       };
@@ -129,8 +146,8 @@ export function useAuctionForm({
         category: auctionCategory,
         description: auctionDescription,
         start_price: Number(startPrice),
-        start_time: startDate,
-        end_time: endDate,
+        start_time: finalStartDate,
+        end_time: finalEndDate,
         thumbnail: images[0] || '',
         images,
       };

--- a/apps/web/features/auction/ui/AuctionCardBase.tsx
+++ b/apps/web/features/auction/ui/AuctionCardBase.tsx
@@ -6,6 +6,7 @@ export interface AuctionCardBaseProps extends CardProps {
   locationName: string;
   imageSrc: string;
   endTime: Date | string;
+  startTime?: Date | string;
   badgeVariant?: 'best' | 'urgent' | null;
   children: React.ReactNode;
 }
@@ -15,6 +16,7 @@ export const AuctionCardBase = ({
   locationName,
   imageSrc,
   endTime,
+  startTime,
   badgeVariant,
   children,
 }: AuctionCardBaseProps) => {
@@ -26,6 +28,7 @@ export const AuctionCardBase = ({
         title={title}
         locationName={locationName}
         endTime={endTime}
+        startTime={startTime}
       />
       {children}
     </div>

--- a/apps/web/shared/lib/utils/isAuctionStarted.ts
+++ b/apps/web/shared/lib/utils/isAuctionStarted.ts
@@ -1,0 +1,5 @@
+export function isAuctionStarted(startTime: Date | string): boolean {
+  const start =
+    typeof startTime === 'string' ? new Date(startTime.replace(' ', 'T') + 'Z') : startTime;
+  return start.getTime() <= Date.now();
+}

--- a/apps/web/shared/lib/validators/auctionAddSchema.ts
+++ b/apps/web/shared/lib/validators/auctionAddSchema.ts
@@ -1,16 +1,48 @@
 import { z } from 'zod';
 
-export const auctionAddSchema = z.object({
-  images: z
-    .array(z.string())
-    .min(1, '사진을 1장 이상 등록해 주세요.')
-    .max(5, '사진은 최대 5장까지 등록할 수 있습니다.'),
-  auctionName: z.string().min(1, '경매 이름을 입력해 주세요.'),
-  auctionCategory: z.string().min(1, '경매 카테고리를 선택해 주세요.'),
-  startPrice: z.string().min(1, '경매 시작가를 입력해 주세요.'),
-  auctionDescription: z.string().min(1, '상품 정보를 입력해 주세요.'),
-  startDate: z.string().min(1, '경매 시작일을 선택해 주세요.'),
-  endDate: z.string().min(1, '경매 종료일을 선택해 주세요.'),
-});
+export const auctionAddSchema = z
+  .object({
+    images: z
+      .array(z.string())
+      .min(1, '사진을 1장 이상 등록해 주세요.')
+      .max(5, '사진은 최대 5장까지 등록할 수 있습니다.'),
+    auctionName: z
+      .string()
+      .min(1, '경매 이름을 입력해 주세요.')
+      .max(10, '상품명은 20자 이하로 입력해 주세요'),
+    auctionCategory: z.string().min(1, '경매 카테고리를 선택해 주세요.'),
+    startPrice: z
+      .string()
+      .min(1, '경매 시작가를 입력해 주세요.')
+      .refine(
+        (val) => {
+          const price = parseInt(val, 10);
+          return price >= 1000;
+        },
+        {
+          message: '경매 시작가는 1,000원 이상이어야 합니다.',
+        }
+      ),
+
+    auctionDescription: z
+      .string()
+      .min(10, '상품 설명은 10자 이상 입력해 주세요.')
+      .max(500, '상품 설명을 500자 이하로 입력해주세요'),
+    startDate: z.string().min(1, '경매 시작일을 선택해 주세요.'),
+    endDate: z.string().min(1, '경매 종료일을 선택해 주세요.'),
+  })
+  .refine(
+    (data) => {
+      const startDate = new Date(data.startDate);
+      const endDate = new Date(data.endDate);
+      const differenceInMs = endDate.getTime() - startDate.getTime();
+      const oneDayInMs = 24 * 60 * 60 * 1000;
+      return differenceInMs >= oneDayInMs;
+    },
+    {
+      message: '경매 종료일은 시작일 이후여야 합니다.',
+      path: ['endDate'],
+    }
+  );
 
 export type AuctionAddFormType = z.infer<typeof auctionAddSchema>;

--- a/apps/web/shared/lib/validators/auctionAddSchema.ts
+++ b/apps/web/shared/lib/validators/auctionAddSchema.ts
@@ -9,7 +9,7 @@ export const auctionAddSchema = z
     auctionName: z
       .string()
       .min(1, '경매 이름을 입력해 주세요.')
-      .max(10, '상품명은 20자 이하로 입력해 주세요'),
+      .max(20, '상품명은 20자 이하로 입력해 주세요'),
     auctionCategory: z.string().min(1, '경매 카테고리를 선택해 주세요.'),
     startPrice: z
       .string()

--- a/apps/web/widgets/auction-detail-card/ui/AuctionDetailCard.tsx
+++ b/apps/web/widgets/auction-detail-card/ui/AuctionDetailCard.tsx
@@ -18,6 +18,7 @@ interface AuctionDetailCardProps {
   isProgressing?: boolean;
   auctionId: string;
   sellerId: string;
+  isAuctionStarted: boolean;
   onMinus: () => void;
   onPlus: () => void;
   onClick: () => void;
@@ -33,13 +34,19 @@ export const AuctionDetailCard = ({
   isProgressing,
   auctionId,
   sellerId,
+  isAuctionStarted,
   onMinus,
   onPlus,
   onClick,
 }: AuctionDetailCardProps) => {
   const userId = useAuthStore().userId;
   const { mutate } = useDeleteAuction();
+
   const handleDelete = () => {
+    if (isAuctionStarted) {
+      alert('경매가 시작되어 삭제가 불가능합니다.');
+      return;
+    }
     if (userId !== sellerId) {
       return alert('본인 경매만 삭제할 수 있습니다.');
     }
@@ -57,7 +64,7 @@ export const AuctionDetailCard = ({
           <p className={auctionDetailCardStyle.auctionDetailCardCurrentPriceLabelStyle}>
             현재 입찰가
           </p>
-          {userId === sellerId && (
+          {userId === sellerId && !isAuctionStarted && (
             <div className={auctionDetailCardStyle.auctionDetailCardEditButtonContainerStyle}>
               <Link href={`/auction/${auctionId}/auction-edit`}>
                 <Button variants="primary">수정하기</Button>

--- a/apps/web/widgets/auction-listings/ui/AuctionListings.tsx
+++ b/apps/web/widgets/auction-listings/ui/AuctionListings.tsx
@@ -1,12 +1,12 @@
 'use client';
 import Link from 'next/link';
 
+import { AuctionCardBase } from '@/features/auction/ui/AuctionCardBase';
+import { AuctionContent } from '@/features/auction/ui/AuctionCardContent';
 import { AuctionOverlay } from '@/features/auction/ui/AuctionOverlay';
 import { AuctionCardProps } from '@/shared/types/auction';
 import { Button } from '@repo/ui/design-system/base-components/Button/index';
 import { auctionListStyle } from './styles/AuctionListings.styles';
-import { AuctionCardBase } from '@/features/auction/ui/AuctionCardBase';
-import { AuctionContent } from '@/features/auction/ui/AuctionCardContent';
 
 interface MockAuctionCardProps extends AuctionCardProps {
   id: string;
@@ -29,6 +29,7 @@ export const AuctionListings = ({ listData }: { listData: MockAuctionCardProps[]
                 locationName={item.locationName}
                 imageSrc={item.imageSrc}
                 endTime={item.endTime}
+                startTime={item.startTime}
               >
                 <AuctionContent
                   primaryLabel="시작가"

--- a/apps/web/widgets/my-listings/ui/MyListings.tsx
+++ b/apps/web/widgets/my-listings/ui/MyListings.tsx
@@ -1,11 +1,11 @@
 import Link from 'next/link';
 
-import { AuctionOverlay } from '@/features/auction/ui/AuctionOverlay';
-import { Button } from '@repo/ui/design-system/base-components/Button/index';
-import { auctionListStyle } from '@/widgets/auction-listings/ui/styles/AuctionListings.styles';
 import { AuctionCardBase } from '@/features/auction/ui/AuctionCardBase';
 import { AuctionContent } from '@/features/auction/ui/AuctionCardContent';
+import { AuctionOverlay } from '@/features/auction/ui/AuctionOverlay';
 import { AuctionCardProps } from '@/shared/types/auction';
+import { auctionListStyle } from '@/widgets/auction-listings/ui/styles/AuctionListings.styles';
+import { Button } from '@repo/ui/design-system/base-components/Button/index';
 
 interface MockAuctionCardProps extends AuctionCardProps {
   id: string;
@@ -28,6 +28,7 @@ export const MyListings = ({ listData }: { listData: MockAuctionCardProps[] }) =
                 locationName={item.locationName}
                 imageSrc={item.imageSrc}
                 endTime={item.endTime}
+                startTime={item.startTime}
                 badgeVariant={item.badgeVariant}
               >
                 <AuctionContent

--- a/apps/web/widgets/my-participated/ui/MyParticipatedAuctions.tsx
+++ b/apps/web/widgets/my-participated/ui/MyParticipatedAuctions.tsx
@@ -1,10 +1,10 @@
 import Link from 'next/link';
 
-import { Button } from '@repo/ui/design-system/base-components/Button/index';
-import { auctionListStyle } from '@/widgets/auction-listings/ui/styles/AuctionListings.styles';
-import { AuctionCardBase, AuctionCardBaseProps } from '@/features/auction/ui/AuctionCardBase';
+import { AuctionCardBase } from '@/features/auction/ui/AuctionCardBase';
 import { AuctionContent } from '@/features/auction/ui/AuctionCardContent';
 import { AuctionCardProps } from '@/shared/types/auction';
+import { auctionListStyle } from '@/widgets/auction-listings/ui/styles/AuctionListings.styles';
+import { Button } from '@repo/ui/design-system/base-components/Button/index';
 
 interface MockAuctionCardProps extends AuctionCardProps {
   id: string;
@@ -27,6 +27,7 @@ export const MyParticipatedAuctions = ({ listData }: { listData: MockAuctionCard
                 locationName={item.locationName}
                 imageSrc={item.imageSrc}
                 endTime={item.endTime}
+                startTime={item.startTime}
                 badgeVariant={item.badgeVariant}
               >
                 <AuctionContent

--- a/apps/web/widgets/my-won-auctions/ui/MyWonAuctions.tsx
+++ b/apps/web/widgets/my-won-auctions/ui/MyWonAuctions.tsx
@@ -1,9 +1,9 @@
 import Link from 'next/link';
 
-import { auctionListStyle } from '@/widgets/auction-listings/ui/styles/AuctionListings.styles';
 import { AuctionCardBase } from '@/features/auction/ui/AuctionCardBase';
 import { AuctionContent } from '@/features/auction/ui/AuctionCardContent';
 import { AuctionCardProps } from '@/shared/types/auction';
+import { auctionListStyle } from '@/widgets/auction-listings/ui/styles/AuctionListings.styles';
 
 interface MockAuctionCardProps extends AuctionCardProps {
   id: string;
@@ -25,6 +25,7 @@ export const MyWonAuctions = ({ listData }: { listData: MockAuctionCardProps[] }
                 locationName={item.locationName}
                 imageSrc={item.imageSrc}
                 endTime={item.endTime}
+                startTime={item.startTime}
               >
                 <AuctionContent
                   primaryLabel="시작가"

--- a/packages/ui/src/design-system/base-components/Card/Card.tsx
+++ b/packages/ui/src/design-system/base-components/Card/Card.tsx
@@ -9,10 +9,11 @@ export interface CardProps {
   title: string;
   locationName: string;
   endTime: Date | string;
+  startTime?: Date | string;
 }
 
-const Card = ({ imageSrc, badgeVariant, title, locationName, endTime }: CardProps) => {
-  const leftTime = getTimeLeftString(endTime);
+const Card = ({ imageSrc, badgeVariant, title, locationName, endTime, startTime }: CardProps) => {
+  const leftTime = getTimeLeftString({ endDate: endTime, startDate: startTime });
   const badgeTitle =
     badgeVariant === 'best' ? '인기' : badgeVariant === 'urgent' ? '마감임박' : null;
   return (

--- a/packages/ui/src/utils/getTimeLeftString.ts
+++ b/packages/ui/src/utils/getTimeLeftString.ts
@@ -1,11 +1,48 @@
-export function getTimeLeftString(endDate: Date | string): string {
+interface TimeLeftProps {
+  endDate: Date | string;
+  startDate?: Date | string | null;
+}
+
+export function getTimeLeftString({ endDate, startDate }: TimeLeftProps): string {
   const now = new Date();
-  const end = typeof endDate === 'string' ? new Date(endDate) : endDate;
-  let diff = Math.max(0, end.getTime() - now.getTime());
 
-  const hours = Math.floor(diff / (1000 * 60 * 60));
-  diff -= hours * 1000 * 60 * 60;
-  const minutes = Math.floor(diff / (1000 * 60));
+  const parseDate = (date: Date | string | null | undefined): Date | null => {
+    if (!date) return null;
+    if (date instanceof Date) return date;
+    // DB에서 오는 'YYYY-MM-DD HH:MM:SS' 형식의 문자열을 UTC로 해석하도록 처리
+    const isoString = date.replace(' ', 'T') + 'Z';
+    const parsedDate = new Date(isoString);
+    return isNaN(parsedDate.getTime()) ? null : parsedDate;
+  };
 
-  return `${hours}시간 ${minutes}분`;
+  const formatTime = (diff: number): string => {
+    const totalHours = Math.floor(diff / (1000 * 60 * 60));
+    const minutes = Math.floor((diff / 1000 / 60) % 60);
+    if (totalHours === 0 && minutes === 0) {
+      return '1분 미만';
+    }
+    return `${totalHours}시간 ${minutes}분`;
+  };
+
+  const start = parseDate(startDate);
+  const end = parseDate(endDate);
+
+  if (!end) {
+    return '유효하지 않은 종료 날짜';
+  }
+
+  // 경매 시작 전
+  if (start && start.getTime() > now.getTime()) {
+    const diff = start.getTime() - now.getTime();
+    return `시작까지 ${formatTime(diff)}`;
+  }
+
+  // 경매 진행 중 또는 종료
+  const diff = end.getTime() - now.getTime();
+
+  if (diff <= 0) {
+    return '경매 종료';
+  }
+
+  return formatTime(diff);
 }


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #191  -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용
누락된 스키마 추가 및 경매 시작 시간을 당일로 설정시 대기시간 10분 설정되도록 추가했습니다.
이에 따라 등록 및 수정 시 10분의 대기시간이 추가 된다는 메시지와 함께 confirm을 받도록 수정했습니다.
추가로 남은 시간이 시간대가 맞지 않았던 현상이 db 상에 UTC 시간을 기준으로 등록되었으나 타입이 timestemp이기 때문에 데이터를 가져올 때, 현지 시간으로 바뀌지 않던 현상이 있습니다. db의 타입을 교체하기엔 로직이 얽혀있어 위험하다고 판단 클라이언트에서 계산을 통해 렌더링 되도록 수정했습니다.
- 이 사항이 main 페이지에도 발생 중입니다. 정찬님은 확인 해보시면 좋을 것 같습니다.
## 🔧 변경 사항
- 스키마 추가
- 경매 대기시간 10분 설정
- 대기시간 안내 및 등록 여부 confirm 추가
- 시간대 맞지 않던 현상 수정 및 시작 전이면 '시작까지 00시 00분'으로 출력

## 📸 스크린샷 (선택 사항)

- 남은 시간
<img width="386" height="341" alt="image" src="https://github.com/user-attachments/assets/b0837143-d9d7-4721-a326-a529d97e2dd0" />

- 경매 시작 이후
<img width="365" height="315" alt="image" src="https://github.com/user-attachments/assets/b4d4947a-4ea0-4116-bb1c-1fb981cc1365" />

- 경매 등록 시 alert 
<img width="446" height="185" alt="image" src="https://github.com/user-attachments/assets/877344a8-5677-459f-9f54-cb16d1f256db" />

- 경매 수정 시 alert
<img width="445" height="180" alt="image" src="https://github.com/user-attachments/assets/bbdab479-325c-4dd8-b488-9de33a1074ae" />

## 📄 기타
