### PR TITLE
fix: 프로필 이미지 null 처리 조건문 수정

### DIFF
--- a/apps/web/features/profile/ui/ProfileAvatarUpload.tsx
+++ b/apps/web/features/profile/ui/ProfileAvatarUpload.tsx
@@ -7,13 +7,15 @@ import { FaCamera } from 'react-icons/fa6';
 
 interface AvatarUploadProps {
   username: string;
-  avatarUrl?: string; // ProfileForm에서 관리하는 현재 미리보기 URL
+  originalAvatarUrl?: string; // DB에 저장된 원본 아바타 URL
+  previewAvatarUrl?: string; // ProfileForm에서 관리하는 현재 미리보기 URL
   onFileSelect: (file: File | undefined) => void; // 선택된 File 객체를 상위로 전달하는 콜백
 }
 
 export const ProfileAvatarUpload = ({
   username,
-  avatarUrl, // ProfileForm에서 이미 캐시 버스터가 붙어 전달된 URL 사용
+  originalAvatarUrl,
+  previewAvatarUrl, // ProfileForm에서 이미 캐시 버스터가 붙어 전달된 URL 사용
   onFileSelect,
 }: AvatarUploadProps) => {
   const imageRef = useRef<HTMLInputElement>(null);
@@ -32,6 +34,11 @@ export const ProfileAvatarUpload = ({
     }
   };
 
+  if (previewAvatarUrl === undefined && originalAvatarUrl) {
+    // DB에 저장된 원본 아바타 URL이 있는데, 아직 avatarUrl 세팅 중이면 로딩
+    return <div>loading...</div>;
+  }
+
   return (
     <div className="flex justify-center">
       <div className="relative inline-flex">
@@ -43,7 +50,13 @@ export const ProfileAvatarUpload = ({
           onChange={handleImageChange}
           data-testid="file-input"
         />
-        <Avatar src={avatarUrl} alt={username} name={username} size="xxl" className="relative" />
+        <Avatar
+          src={previewAvatarUrl}
+          alt={username}
+          name={username}
+          size="xxl"
+          className="relative"
+        />
         <p
           onClick={imageClick}
           role="button"

--- a/apps/web/features/profile/ui/ProfileAvatarUpload.tsx
+++ b/apps/web/features/profile/ui/ProfileAvatarUpload.tsx
@@ -32,10 +32,6 @@ export const ProfileAvatarUpload = ({
     }
   };
 
-  if (!avatarUrl) {
-    return <div>loading...</div>;
-  }
-
   return (
     <div className="flex justify-center">
       <div className="relative inline-flex">

--- a/apps/web/widgets/profile/ui/ProfileForm.tsx
+++ b/apps/web/widgets/profile/ui/ProfileForm.tsx
@@ -8,9 +8,9 @@ import { ZodFormattedError } from 'zod';
 
 import { handleInputChange, handleSubmit } from '@/features/profile/model/handlers';
 import { ProfileAvatarUpload } from '@/features/profile/ui/ProfileAvatarUpload';
-import { ProfileFormType, UserProfileType } from '@/shared/types/profile';
-import { getCacheBustingUrl } from '@/shared/lib/utils/avatar';
 import { useUpdateProfile } from '@/shared/api/client/profile/useUpdateProfile';
+import { getCacheBustingUrl } from '@/shared/lib/utils/avatar';
+import { ProfileFormType, UserProfileType } from '@/shared/types/profile';
 
 export const ProfileForm = ({ user }: { user: UserProfileType }) => {
   // 1. 초기 상태는 user.avatar의 순수한 URL로 설정.
@@ -32,6 +32,7 @@ export const ProfileForm = ({ user }: { user: UserProfileType }) => {
   useEffect(() => {
     // selectedFile이 없고, user.avatar가 존재할 때만 캐시 버스팅을 적용
     // 이는 사용자가 새 파일을 선택하기 전의 기본 아바타에만 해당
+
     if (!selectedFile && user.avatar) {
       setAvatarPreviewUrl(getCacheBustingUrl(user.avatar));
     }
@@ -55,8 +56,9 @@ export const ProfileForm = ({ user }: { user: UserProfileType }) => {
       <h1 className="mb-3 text-base font-semibold">내 정보 수정</h1>
       <ProfileAvatarUpload
         username={user.username}
-        avatarUrl={avatarPreviewUrl}
+        previewAvatarUrl={avatarPreviewUrl}
         onFileSelect={handleFileSelect}
+        originalAvatarUrl={user.avatar}
       />
       <form
         onSubmit={(e) =>


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용
프로필 업데이트 페이지에서 아바타 이미지가 없을 때 loading 처리 조건문 수정
- 기존에 아바타 이미지를 가져오는 동안 loading 문구로 대체 하였는데 이 방식은 아바타 이미지가 없는 경우를 고려하지 않았습니다.
(처음 회원가입 시에는 아바타 이미지가 없음.  프로필 사진을 변경하기 전까지는 기본 이미지임)
- 위의 조건문으로 인해 아바타 이미지가 없을 때 (첫 회원가입 시) loading.. 문구가 계속 보여지는 현상이 발생했습니다. 
```
if (!avatarUrl) {
    return <div>loading...</div>;
  }
```

`user.avatar`가 아예 없는(신규 회원) 경우에는 기본 이미지를 보여주고,
`avatarUrl`이 아직 세팅 중일 때만 loading을 보여주도록 조건문을 수정하였습니다. 
- ProfileAvatarUpload에 previewAvatarUrl props 추가 
```
interface AvatarUploadProps {
  username: string;
  originalAvatarUrl?: string; // DB에 저장된 원본 아바타 URL
  previewAvatarUrl?: string; // ProfileForm에서 관리하는 현재 미리보기 URL
  onFileSelect: (file: File | undefined) => void; // 선택된 File 객체를 상위로 전달하는 콜백
}

export const ProfileAvatarUpload = ({
  username,
  originalAvatarUrl,
  previewAvatarUrl, // ProfileForm에서 이미 캐시 버스터가 붙어 전달된 URL 사용
  onFileSelect,
}: AvatarUploadProps) => {
..
if (previewAvatarUrl === undefined && originalAvatarUrl) {
    // DB에 저장된 원본 아바타 URL이 있는데, 아직 avatarUrl 세팅 중이면 로딩
    return <div>loading...</div>;
  }
}


<ProfileAvatarUpload
    username={user.username}
    previewAvatarUrl={avatarPreviewUrl}
    onFileSelect={handleFileSelect}
    originalAvatarUrl={user.avatar}
  />
```

## 🔧 변경 사항

## 📸 스크린샷 (선택 사항)

## 📄 기타
