### PR TITLE
[fix] : 경매 페이지 관련 status 계산 오류 해결

### DIFF
--- a/apps/web/features/auction/ui/AuctionBidHistoryCard.tsx
+++ b/apps/web/features/auction/ui/AuctionBidHistoryCard.tsx
@@ -4,8 +4,8 @@ import { Bid } from '@/shared/types/db';
 import { auctionBidHistoryStyle } from './styles/AuctionBidHistoryCard.styles';
 
 export const AuctionBidHistoryCard = ({ bid }: { bid: Bid }) => {
-  const dateObj = new Date(bid.bid_time);
-  const dateStr = dateObj.toLocaleDateString('en-US', {
+  const dateObj = new Date(bid.bid_time + 'Z');
+  const dateStr = dateObj.toLocaleDateString('ko-KR', {
     year: 'numeric',
     month: '2-digit',
     day: '2-digit',

--- a/apps/web/shared/lib/utils/auctionStatus.ts
+++ b/apps/web/shared/lib/utils/auctionStatus.ts
@@ -1,8 +1,20 @@
 export function getAuctionStatus(item: { start_time?: string; end_time?: string }) {
   let status: 'ready' | 'in progress' | 'end' = 'ready';
   const now = new Date();
-  const start = item.start_time ? new Date(item.start_time) : null;
-  const end = item.end_time ? new Date(item.end_time) : null;
+
+  const parseUTCDate = (dateString?: string): Date | null => {
+    if (!dateString) return null;
+    // 'Z'를 붙여 UTC로 해석하도록 강제
+    const isoString = dateString.includes('T')
+      ? dateString + 'Z'
+      : dateString.replace(' ', 'T') + 'Z';
+    const date = new Date(isoString);
+    return isNaN(date.getTime()) ? null : date;
+  };
+
+  const start = parseUTCDate(item.start_time);
+  const end = parseUTCDate(item.end_time);
+
   if (start && end) {
     if (now < start) status = 'ready';
     else if (now >= start && now <= end) status = 'in progress';


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #224 -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용
경매 상세 페이지에서 발견된 실제 경매 시간이 종료가 되지 않았음에도 경매 종료처리되는 문제를 해결했습니다.
데이터를 fetch해오는 과정에서 status를 start_time과 end_time을 받아와 계산 현재 시간과 비교하여 새로운 status 값을 넣는 과정에서 함수에 timeStemp 타입임에도 불구 UTC타입으로 들어온다는 것을 선언하지 않아 발생하던 오류가 있는 것을 발견 해당 함수 로직을 수정했습니다.

추가로 경매 상세페이지의 입찰 기록카드 부분의 시간도 현지 시간에 맞게 수정하고, 
날짜 부분이 한국 정서에 읽기 힘들다고 판단 기존 `월/일/년` 으로 출력되던 것을 `년/월/일`로 변경하였습니다.

## 🔧 변경 사항
- status 계산 함수 로직 수정
- 입찰 기록카드 시간 로직 수정

## 📸 스크린샷 (선택 사항)
- 입찰기록 변경사항
<img width="308" height="605" alt="image" src="https://github.com/user-attachments/assets/64e39698-110d-48ed-97e8-b6beb4d55944" />

## 📄 기타
