### PR TITLE
[Chore] : vercel analytics google analytics #172

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -7,6 +7,7 @@ import { Providers } from './providers';
 import '@repo/ui/styles';
 import { cookies } from 'next/headers';
 import './globals.css';
+import { Analytics } from '@vercel/analytics/next';
 
 const notoSansKR = Noto_Sans_KR({
   subsets: ['latin'],
@@ -29,6 +30,9 @@ export const metadata: Metadata = {
 import { NotificationPermissionButton } from '@/features/test/NotificationPermissionButton';
 import { PushSubscriptionEffect } from '@/shared/hooks/PushSubscriptionEffect';
 import * as Sentry from '@sentry/nextjs';
+import GoogleAnalytics from '@/shared/hooks/GoogleAnalyticsEffect';
+import Script from 'next/script';
+import { GA_TRACKING_ID } from '@/shared/lib/ga4/gtag';
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
   const theme = (await cookies()).get('theme')?.value ?? 'light';
@@ -43,6 +47,22 @@ export default async function RootLayout({ children }: { children: React.ReactNo
           <Providers>
             <PushSubscriptionEffect />
             {children}
+            <Analytics />
+            <GoogleAnalytics />
+            <Script
+              src={`https://www.googletagmanager.com/gtag/js?id=${GA_TRACKING_ID}`}
+              strategy="afterInteractive"
+            />
+            <Script id="google-analytics" strategy="afterInteractive">
+              {`
+                window.dataLayer = window.dataLayer || [];
+                function gtag(){dataLayer.push(arguments);}
+                gtag('js', new Date());
+                gtag('config', '${GA_TRACKING_ID}', {
+                  page_path: window.location.pathname,
+                });
+              `}
+            </Script>
           </Providers>
         </Sentry.ErrorBoundary>
       </body>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,6 +22,7 @@
     "@supabase/ssr": "^0.6.1",
     "@supabase/supabase-js": "^2.50.0",
     "@tanstack/react-query": "^5.80.10",
+    "@vercel/analytics": "^1.5.0",
     "date-fns": "^4.1.0",
     "framer-motion": "^12.23.6",
     "next": "^15.3.0",

--- a/apps/web/shared/hooks/GoogleAnalyticsEffect.tsx
+++ b/apps/web/shared/hooks/GoogleAnalyticsEffect.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { usePathname, useSearchParams } from 'next/navigation';
+import { useEffect } from 'react';
+import { pageview } from '../lib/ga4/gtag';
+
+export default function GoogleAnalytics() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    const query = searchParams.toString();
+    const url = query ? `${pathname}?${query}` : pathname;
+
+    pageview(url);
+  }, [pathname, searchParams]);
+
+  return null;
+}

--- a/apps/web/shared/lib/ga4/gtag.ts
+++ b/apps/web/shared/lib/ga4/gtag.ts
@@ -1,0 +1,29 @@
+export const GA_TRACKING_ID = process.env.NEXT_PUBLIC_GA_ID;
+
+export const pageview = (url: string) => {
+  if (typeof window !== 'undefined' && GA_TRACKING_ID) {
+    window.gtag('config', GA_TRACKING_ID, {
+      page_path: url,
+    });
+  }
+};
+
+export const event = ({
+  action,
+  category,
+  label,
+  value,
+}: {
+  action: string;
+  category: string;
+  label?: string;
+  value?: number;
+}) => {
+  if (typeof window !== 'undefined') {
+    window.gtag('event', action, {
+      event_category: category,
+      event_label: label,
+      value: value,
+    });
+  }
+};

--- a/apps/web/shared/types/gtag/gtag.d.ts
+++ b/apps/web/shared/types/gtag/gtag.d.ts
@@ -1,0 +1,18 @@
+declare global {
+  interface Window {
+    gtag: (
+      command: 'config' | 'event' | 'js' | 'set',
+      targetId: string | Date,
+      config?: {
+        page_path?: string;
+        event_category?: string;
+        event_label?: string;
+        value?: number;
+        [key: string]: any;
+      }
+    ) => void;
+    dataLayer: any[];
+  }
+}
+
+export {};

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -22,7 +22,8 @@
     "**/*.tsx",
     "next-env.d.ts",
     "next.config.ts",
-    ".next/types/**/*.ts"
+    ".next/types/**/*.ts",
+    "shared/types/**/*.d.ts"
   ],
   "exclude": [
     "node_modules",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -202,6 +202,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.80.10
         version: 5.80.10(react@19.1.0)
+      '@vercel/analytics':
+        specifier: ^1.5.0
+        version: 1.5.0(next@15.3.3)(react@19.1.0)
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
@@ -5171,6 +5174,36 @@ packages:
     requiresBuild: true
     dev: true
     optional: true
+
+  /@vercel/analytics@1.5.0(next@15.3.3)(react@19.1.0):
+    resolution: {integrity: sha512-MYsBzfPki4gthY5HnYN7jgInhAZ7Ac1cYDoRWFomwGHWEX7odTEzbtg9kf/QSo7XEsEAqlQugA6gJ2WS2DEa3g==}
+    peerDependencies:
+      '@remix-run/react': ^2
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
+    dependencies:
+      next: 15.3.3(@babel/core@7.27.4)(@opentelemetry/api@1.9.0)(react-dom@19.1.0)(react@19.1.0)
+      react: 19.1.0
+    dev: false
 
   /@vitejs/plugin-react@4.6.0(vite@6.3.5):
     resolution: {integrity: sha512-5Kgff+m8e2PB+9j51eGHEpn5kUzRKH2Ry0qGoe8ItJg7pqnkPrYPkDQZGgGmTa0EGarHrkjLvOdU3b1fzI8otQ==}


### PR DESCRIPTION
## 📋 작업 내용
- vercel analytics & google analytics 연동
- 둘 다 배포가 되어야 최종 확인 가능

- verce analytics는 pro버젼 사용 예정으로 라이브러리 설치와 layout위치에 setting (pro사용시 별다른 추가 셋팅없이 바로 사용 가능)
- google analytics 대쉬보드에 생성한 스트림 ID연동 (GA4의 관련한 문서를 작성하였습니다.)

- gtag.ts 에 정의한 event 를 원하는 클릭 이벤트에 호출하여 수치를 얻고 싶은 사용자의 특정 행동을 추적 할 수 있습니다. (ex: like 버튼, 입찰버튼 등등 )
- 추후 발생하는 이벤트를 어디에 추적할지 회의를 통하여 이 gtag의 event를 각 이벤트에 호출하여야 합니다.
ex): 
```
const LikeHandleClick = () => {
  event({
    action: 'click_like',
    category: 'product',
    label: '중고상품_찜버튼',
    value: 1,
  });
};
```

