### PR TITLE
[feat] : 경매 관련 페이지 남은 시간 타이머 구현

### DIFF
--- a/apps/web/app/(main)/auction/[auctionId]/auction-detail/page.tsx
+++ b/apps/web/app/(main)/auction/[auctionId]/auction-detail/page.tsx
@@ -3,6 +3,7 @@
 import { isAuctionStarted } from '@/shared/lib/utils/isAuctionStarted';
 import { getTimeLeftString } from '@repo/ui/utils/getTimeLeftString';
 import { useParams } from 'next/navigation';
+import { useEffect, useState } from 'react';
 
 import {
   AuctionDescriptionCard,
@@ -17,7 +18,7 @@ import { useAuthStore } from '@/shared/stores/auth';
 
 const Page = () => {
   const params = useParams();
-  const auctionId = params.auctionId as string;
+  const auctionId = params?.auctionId as string;
   const userId = useAuthStore().userId;
   const {
     data,
@@ -32,6 +33,19 @@ const Page = () => {
     minBidCostNumber,
   } = useAuctionBidState(auctionId);
 
+  const [displayRemainingTime, setDisplayRemainingTime] = useState('');
+
+  useEffect(() => {
+    if (data) {
+      const interval = setInterval(() => {
+        setDisplayRemainingTime(
+          getTimeLeftString({ endDate: data.end_time, startDate: data.start_time })
+        );
+      }, 1000);
+      return () => clearInterval(interval);
+    }
+  }, [data]);
+
   if (isLoading) return <div>로딩 중...</div>;
   if (error) return <div>에러: {error.message}</div>;
   if (!data) return <div>데이터가 없습니다.</div>;
@@ -40,8 +54,7 @@ const Page = () => {
   const imageFiles = data.images || [];
   const auctionName = product.name;
   const startBidCost = data.start_price;
-  const remainingTime = getTimeLeftString({ endDate: data.end_time, startDate: data.start_time });
-  const bidUnit = 5000; // 입찰 단위
+  const bidUnit = 5000;
   const auctionStarted = isAuctionStarted(data.start_time);
 
   return (
@@ -51,7 +64,7 @@ const Page = () => {
       <AuctionDetailCard
         currentBidCost={displayCurrentPrice}
         startBidCost={startBidCost}
-        remainingTime={remainingTime}
+        remainingTime={displayRemainingTime}
         minBidCost={minBidCostNumber}
         bidUnit={bidUnit}
         bidCost={bidCost}

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/ui/src/design-system/base-components/Card/Card.tsx
+++ b/packages/ui/src/design-system/base-components/Card/Card.tsx
@@ -1,8 +1,12 @@
+'use client';
+
+import { useEffect, useState } from 'react'; // useState, useEffect 추가
 import { FaRegClock } from 'react-icons/fa6';
 import { getTimeLeftString } from '../../../utils/getTimeLeftString';
 import { Badge } from '../Badge';
 import { LocationInfo } from '../LocationInfo';
 import { cardStyle } from './Card.styles';
+
 export interface CardProps {
   imageSrc: string;
   badgeVariant?: 'best' | 'urgent' | null;
@@ -13,7 +17,15 @@ export interface CardProps {
 }
 
 const Card = ({ imageSrc, badgeVariant, title, locationName, endTime, startTime }: CardProps) => {
-  const leftTime = getTimeLeftString({ endDate: endTime, startDate: startTime });
+  const [displayRemainingTime, setDisplayRemainingTime] = useState(''); // 새로운 상태 추가
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setDisplayRemainingTime(getTimeLeftString({ endDate: endTime, startDate: startTime }));
+    }, 1000);
+    return () => clearInterval(interval); // 클린업 함수
+  }, [endTime, startTime]); // endTime, startTime이 변경될 때마다 useEffect 재실행
+
   const badgeTitle =
     badgeVariant === 'best' ? '인기' : badgeVariant === 'urgent' ? '마감임박' : null;
   return (
@@ -30,7 +42,7 @@ const Card = ({ imageSrc, badgeVariant, title, locationName, endTime, startTime 
         <LocationInfo address={locationName} />
         <div className={cardStyle.cardInfoLeftTimeStyle}>
           <FaRegClock />
-          {leftTime}
+          {displayRemainingTime}
         </div>
       </div>
       <span className={cardStyle.cardTitleStyle}>{title}</span>

--- a/packages/ui/src/utils/getTimeLeftString.ts
+++ b/packages/ui/src/utils/getTimeLeftString.ts
@@ -16,12 +16,16 @@ export function getTimeLeftString({ endDate, startDate }: TimeLeftProps): string
   };
 
   const formatTime = (diff: number): string => {
-    const totalHours = Math.floor(diff / (1000 * 60 * 60));
-    const minutes = Math.floor((diff / 1000 / 60) % 60);
-    if (totalHours === 0 && minutes === 0) {
-      return '1분 미만';
-    }
-    return `${totalHours}시간 ${minutes}분`;
+    const totalHours = Math.floor(diff / (1000 * 60 * 60)); // 총 시간을 계산
+    const minutes = Math.floor((diff / (1000 * 60)) % 60);
+    const seconds = Math.floor((diff / 1000) % 60);
+
+    let timeString = '';
+    if (totalHours > 0) timeString += `${totalHours}시간 `;
+    if (minutes > 0 || totalHours > 0) timeString += `${minutes}분 `;
+    timeString += `${seconds}초`;
+
+    return timeString.trim();
   };
 
   const start = parseDate(startDate);


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용
경매 관련 페이지들의 남은 시간들을 타이머로 초단위로 변경되도록 구현했습니다.
## 🔧 변경 사항
- 경매 관련 페이지 타이머 구현

## 📸 스크린샷 (선택 사항)
<img width="433" height="361" alt="image" src="https://github.com/user-attachments/assets/9c36f082-b99c-4050-8b3c-24583b10fe30" />

## 📄 기타
