### PR TITLE
[fix]: realtime- 구독 생명주기가 원인 (#243)

### DIFF
--- a/apps/web/shared/stores/chatSubscriptionStore.ts
+++ b/apps/web/shared/stores/chatSubscriptionStore.ts
@@ -1,0 +1,117 @@
+import { RealtimeChannel, RealtimePostgresChangesFilter } from '@supabase/supabase-js';
+import { create } from 'zustand';
+import { supabase } from '@/shared/lib/supabase/supabase';
+import { Message } from '@/shared/types/chat';
+
+type ChannelName = string;
+
+type SubscriptionOptions = {
+  onInsert: (message: Message) => void;
+  onUpdate: (message: Message) => void;
+};
+
+type ChatSubscriptionState = {
+  channels: Map<ChannelName, RealtimeChannel>;
+  refCounts: Map<ChannelName, number>;
+  subscriptions: Map<ChannelName, SubscriptionOptions>;
+};
+
+type ChatSubscriptionActions = {
+  subscribe: (
+    channelName: ChannelName,
+    options: SubscriptionOptions,
+    insertOptions: RealtimePostgresChangesFilter<'INSERT'>,
+    updateOptions: RealtimePostgresChangesFilter<'UPDATE'>
+  ) => void;
+  unsubscribe: (channelName: ChannelName) => void;
+};
+
+const useChatSubscriptionStore = create<ChatSubscriptionState & ChatSubscriptionActions>(
+  (set, get) => ({
+    channels: new Map(),
+    refCounts: new Map(),
+    subscriptions: new Map(),
+
+    subscribe: (channelName, options, insertOptions, updateOptions) => {
+      set((state) => {
+        const newRefCounts = new Map(state.refCounts);
+        const currentRefCount = newRefCounts.get(channelName) || 0;
+        newRefCounts.set(channelName, currentRefCount + 1);
+
+        const newChannels = new Map(state.channels);
+        const newSubscriptions = new Map(state.subscriptions);
+
+        if (currentRefCount === 0) {
+          const channel = supabase.channel(channelName);
+          channel
+            .on('postgres_changes', insertOptions, (payload) => {
+              console.log(`[Realtime:${channelName}] INSERT`, payload.new);
+              get()
+                .subscriptions.get(channelName)
+                ?.onInsert(payload.new as Message);
+            })
+            .on('postgres_changes', updateOptions, (payload) => {
+              console.log(`[Realtime:${channelName}] UPDATE`, payload.new);
+              get()
+                .subscriptions.get(channelName)
+                ?.onUpdate(payload.new as Message);
+            });
+
+          channel.subscribe((status) => {
+            if (status === 'SUBSCRIBED') {
+              console.log(`[subscribeToMessages] channel ${channelName} subscribed successfully.`);
+            } else {
+              console.error(
+                `[subscribeToMessages] channel ${channelName} subscription error:`,
+                status
+              );
+            }
+          });
+
+          newChannels.set(channelName, channel);
+          newSubscriptions.set(channelName, options);
+
+          return {
+            channels: newChannels,
+            refCounts: newRefCounts,
+            subscriptions: newSubscriptions,
+          };
+        }
+
+        return { refCounts: newRefCounts };
+      });
+    },
+
+    unsubscribe: (channelName) => {
+      set((state) => {
+        const newRefCounts = new Map(state.refCounts);
+        const currentRefCount = newRefCounts.get(channelName);
+
+        if (currentRefCount && currentRefCount > 1) {
+          newRefCounts.set(channelName, currentRefCount - 1);
+          return { refCounts: newRefCounts };
+        }
+
+        const newChannels = new Map(state.channels);
+        const channel = newChannels.get(channelName);
+
+        if (channel) {
+          channel.unsubscribe();
+          newChannels.delete(channelName);
+          newRefCounts.delete(channelName);
+          const newSubscriptions = new Map(state.subscriptions);
+          newSubscriptions.delete(channelName);
+          return {
+            channels: newChannels,
+            refCounts: newRefCounts,
+            subscriptions: newSubscriptions,
+          };
+        }
+
+        return {};
+      });
+    },
+  })
+);
+
+export default useChatSubscriptionStore;


### PR DESCRIPTION
## 📋 작업 내용
- 오류 원인:
subscribeToMessages 을 chatlist 와 ChatMessages 컴포넌트에 둘 다 이용하여 생긴 문제
 chatRoomList 에서 chatMessages로 페이지를 이동하면 chatRoomList 컴포넌트가 언마운트되면서 
 cleanup 함수가 실행되어 구독이 종료되는 오류

즉, 구독의 생명주기가 개별 컴포넌트의 생명주기에 묶여있기 때문.

- 해결 방안:
 구독의 생명주기를 컴포넌트에서 분리하여 zustand로 전역적으로 관리함.
이렇게 하면 페이지 이동 시 컴포넌트가 언마운트 되더라도, 다른 컴포넌트에서 여전히 구독을 사용 중이라면
실제 구독은 해제되지 않고 유지됨.

