### PR TITLE
fix: vercel- build 오류 profile 페이지 동적 렌더링으로 수정

### DIFF
--- a/apps/web/app/(main)/profile/page.tsx
+++ b/apps/web/app/(main)/profile/page.tsx
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic';
+
 import { redirect } from 'next/navigation';
 
 import { Navigation, UserProfileCard } from '@/widgets/profile'; // UserProfileType import 추가


### PR DESCRIPTION
/profile 페이지가 정적으로 렌더링되려고 하는데 cookies를 사용해서 동적 렌더링이 필요하다는 오류

문제 원인

/profile 페이지에서 cookies( )를 사용하고 있음
Next.js가 이 페이지를 정적으로 빌드하려고 시도하지만, 쿠키는 런타임에만 사용 가능

해결방법
- 페이지를 동적으로 설정 
- export const dynamic = 'force-dynamic';
