### PR TITLE
fix: 경매 상세 페이지 중복 입찰 가능했던 버그 수정

### DIFF
--- a/apps/web/features/auction-detail/model/useSendBid.ts
+++ b/apps/web/features/auction-detail/model/useSendBid.ts
@@ -32,6 +32,11 @@ export function useSendBid(
       alert('경매 ID 또는 입찰자 ID가 없습니다.');
       return;
     }
+    const lastBid = data.bids?.[data.bids.length - 1];
+    if (lastBid && lastBid.bidder_id === bidderId) {
+      alert('이미 최고가 입찰자입니다. 중복 입찰이 불가합니다.');
+      return;
+    }
     mutate({
       auctionId,
       bidderId,


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용
중복 입찰이 가능했던 현상이 있어 해당 상황의 유효성 검사가 누락된 것을 확인 유효성 검사를 추가했습니다.
## 🔧 변경 사항
중복 입찰 관련 로직 생성
## 📸 스크린샷 (선택 사항)
<img width="571" height="183" alt="{BDE40F2E-3FEC-4E4A-8D65-BDED0248AC20}" src="https://github.com/user-attachments/assets/8a66c7a5-5a77-4387-9283-f43b1822920e" />

## 📄 기타
