### PR TITLE
[fix] : 경매 리스트 남은 시간 형식 변경 및 Image 컴포넌트 경고 관련 수정

### DIFF
--- a/apps/web/features/auction/ui/AuctionListItem.tsx
+++ b/apps/web/features/auction/ui/AuctionListItem.tsx
@@ -41,7 +41,7 @@ export const AuctionListItem = ({
       className={AuctionListItemStyles.itemContainerStyle}
     >
       <div className={AuctionListItemStyles.itemImageContainerStyle}>
-        <Image src={imageSrc} alt={title} layout="fill" objectFit="cover" />
+        <Image src={imageSrc} alt={title} fill style={{ objectFit: 'cover' }} sizes="96px" />
       </div>
       <div className={AuctionListItemStyles.itemContentsContainerStyle}>
         <p className={AuctionListItemStyles.itemTitleStyle}>{title}</p>

--- a/apps/web/features/auction/ui/AuctionListItem.tsx
+++ b/apps/web/features/auction/ui/AuctionListItem.tsx
@@ -13,6 +13,7 @@ interface AuctionListItemProps {
   startTime: string;
   endTime: string;
   status: 'ready' | 'in_progress' | 'closed';
+  showTimeLeftSeconds?: boolean;
 }
 
 export const AuctionListItem = ({
@@ -24,10 +25,15 @@ export const AuctionListItem = ({
   startTime,
   endTime,
   status,
+  showTimeLeftSeconds = false,
 }: AuctionListItemProps) => {
   const auctionStausText =
     status === 'ready' ? '시작까지' : status === 'in_progress' ? '종료까지' : '경매 종료';
-  const timeLeft = getTimeLeftString({ endDate: endTime, startDate: startTime });
+  const timeLeft = getTimeLeftString({
+    endDate: endTime,
+    startDate: startTime,
+    showSeconds: showTimeLeftSeconds,
+  });
 
   return (
     <Link

--- a/apps/web/features/hotdeal/ui/HotdealListItem.tsx
+++ b/apps/web/features/hotdeal/ui/HotdealListItem.tsx
@@ -25,7 +25,13 @@ export const HotdealListItem = ({ hotdeal }: HotdealListItemProps) => {
       className={AuctionListItemStyles.itemContainerStyle}
     >
       <div className={AuctionListItemStyles.itemImageContainerStyle}>
-        <Image src={hotdeal.image_url} alt={hotdeal.name} layout="fill" objectFit="cover" />
+        <Image
+          src={hotdeal.image_url}
+          alt={hotdeal.name}
+          fill
+          style={{ objectFit: 'cover' }}
+          sizes="96px"
+        />
       </div>
       <div className={AuctionListItemStyles.itemContentsContainerStyle}>
         <p className={AuctionListItemStyles.itemTitleStyle}>{hotdeal.name}</p>

--- a/packages/ui/src/utils/getTimeLeftString.ts
+++ b/packages/ui/src/utils/getTimeLeftString.ts
@@ -1,9 +1,14 @@
 interface TimeLeftProps {
   endDate: Date | string;
   startDate?: Date | string | null;
+  showSeconds?: boolean;
 }
 
-export function getTimeLeftString({ endDate, startDate }: TimeLeftProps): string {
+export function getTimeLeftString({
+  endDate,
+  startDate,
+  showSeconds = true,
+}: TimeLeftProps): string {
   const now = new Date();
 
   const parseDate = (date: Date | string | null | undefined): Date | null => {
@@ -22,10 +27,20 @@ export function getTimeLeftString({ endDate, startDate }: TimeLeftProps): string
 
     const pad = (num: number) => num.toString().padStart(2, '0');
 
-    if (totalHours > 0) {
-      return `${pad(totalHours)}:${pad(minutes)}:${pad(seconds)}`;
+    if (showSeconds) {
+      if (totalHours > 0) {
+        return `${pad(totalHours)}:${pad(minutes)}:${pad(seconds)}`;
+      }
+      return `${pad(minutes)}:${pad(seconds)}`;
     }
-    return `${pad(minutes)}:${pad(seconds)}`;
+
+    if (totalHours > 0) {
+      return `${pad(totalHours)}시간 ${pad(minutes)}분`;
+    }
+    if (minutes === 0) {
+      return '1분 미만';
+    }
+    return `${pad(minutes)}분`;
   };
 
   const start = parseDate(startDate);


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용
경매 리스트에서 hh:mm:ss 형식으로 렌더링 되던 남은 시간을 hh시간 mm분으로 변경하였습니다.
리스트에서 사용하는 Image 컴포넌트에서
 `HotdealListItem.tsx:28 Image with src "https://kqyspmbkzwmwfufzydly.supabase.co/storage/v1/object/public/auction-image//1753855961307_43mv0mlqh22.jpg" has "fill" but is missing "sizes" prop. Please add it to improve page performance.`
경고문구가 발생 이 문제를 해결했습니다.

## 🔧 변경 사항
- 경매 리스트 시간 형식 변경
- Image 컴포넌트의 size 설정 및 fill, objectFit 속성을 next13버전 이후 사용하는 속성으로 변경

## 📸 스크린샷 (선택 사항)
<img width="488" height="813" alt="image" src="https://github.com/user-attachments/assets/5e8e2f83-53b8-45e1-8907-b4748423668a" />

## 📄 기타
