### PR TITLE
[style]: main 폴더 내부 컨텐츠들의 컨텐츠 영역 높이 계산 변경

### DIFF
--- a/apps/web/app/(main)/hotdeal/[hotdealId]/detail/page.tsx
+++ b/apps/web/app/(main)/hotdeal/[hotdealId]/detail/page.tsx
@@ -83,7 +83,7 @@ export default function Page({ params }: { params: Promise<{ hotdealId: string }
 
       <Button
         variants="custom"
-        className="sticky bottom-0 bg-purple-500 text-white transition-colors hover:bg-purple-600"
+        className="sticky bottom-1 bg-purple-500 text-white transition-colors hover:bg-purple-600"
         size="thinLg"
         onClick={handlePurchase}
         disabled={status !== 'ACTIVE' || purchaseMutation.isPending}

--- a/apps/web/app/(main)/hotdeal/[hotdealId]/detail/page.tsx
+++ b/apps/web/app/(main)/hotdeal/[hotdealId]/detail/page.tsx
@@ -83,7 +83,7 @@ export default function Page({ params }: { params: Promise<{ hotdealId: string }
 
       <Button
         variants="custom"
-        className="sticky bottom-1 bg-purple-500 text-white transition-colors hover:bg-purple-600"
+        className="bg-primary-500 hover:bg-primary-600 sticky bottom-1 text-white transition-colors"
         size="thinLg"
         onClick={handlePurchase}
         disabled={status !== 'ACTIVE' || purchaseMutation.isPending}

--- a/apps/web/app/(main)/layout.tsx
+++ b/apps/web/app/(main)/layout.tsx
@@ -1,5 +1,6 @@
 import ModalProvider from '@/widgets/modal/ui/ModalProvider';
 import { ScrollButton } from '@/widgets/scroll-button/ScrollButton';
+
 import { Footer } from '../../widgets/footer';
 import { Header } from '../../widgets/header';
 
@@ -12,7 +13,10 @@ const layout = ({ children }: Props) => {
     <div className="flex h-screen flex-col">
       <Header />
       <ModalProvider />
-      <div id="main-scroll-container" className="relative flex-1 overflow-y-auto px-4 pb-10">
+      <div
+        id="main-scroll-container"
+        className="relative h-[calc(100dvh-68px-80px)] overflow-y-auto px-4"
+      >
         {children}
         <ScrollButton />
       </div>

--- a/apps/web/widgets/loading-spiner/ui/LodingSpinner.tsx
+++ b/apps/web/widgets/loading-spiner/ui/LodingSpinner.tsx
@@ -1,3 +1,3 @@
 export const LoadingSpinner = () => (
-  <div className="h-12 w-12 animate-spin rounded-full border-4 border-gray-200 border-t-purple-500"></div>
+  <div className="border-t-primary-500 h-12 w-12 animate-spin rounded-full border-4 border-gray-200"></div>
 );

--- a/apps/web/widgets/scroll-button/ScrollButton.styles.ts
+++ b/apps/web/widgets/scroll-button/ScrollButton.styles.ts
@@ -1,5 +1,5 @@
 export const ScrollButtonStyle = {
-  container: 'z-30 sticky bottom-12 right-0 float-right',
+  container: 'z-30 sticky bottom-2 right-0 float-right',
   button:
     'rounded-full bg-[var(--button-primary-bg)] p-4 text-[var(--button-primary-text)] hover:bg-[var(--button-primary-bg-hover)]',
 };


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용
기존 flex 기반으로 높이를 계산 하던 방식 때문에 footer가 fixed로 변경됨에 따라 핫딜 상세 페이지에서 구매 버튼이 footer 뒤에 렌더링 되는 것을 확인하였습니다.
이를 방지하기 위해 flex기반으로 컨텐츠 공간이 계산되던 것에서 calc를 통해 뷰포트 높이에서 header와 footer의 높이를 뺀 나머지 공간을 활용하도록 변경하였습니다. => `calc(100dvh - header hight(68px) - footer hight(80px))`

## 🔧 변경 사항
- main 레이아웃 컨텐츠 높이 계산 변경

## 📸 스크린샷 (선택 사항)
![20250731-0156-10 2212460](https://github.com/user-attachments/assets/fd55fa9f-e773-4d51-ad4f-7f0edfe43f4a)

## 📄 기타
