### PR TITLE
refactor: 경매 상세 페이지 입찰 기록을 최근 5개로 변경하며 최근 입찰로 문구 변경

### DIFF
--- a/apps/web/app/(main)/auction/[auctionId]/auction-detail/page.tsx
+++ b/apps/web/app/(main)/auction/[auctionId]/auction-detail/page.tsx
@@ -79,7 +79,6 @@ const Page = () => {
         onClick={sendBid}
       />
       <AuctionSellerProfile user={seller} />
-      {/* <hr className="w-full border border-[var(--border-primary)]" /> */}
       <AuctionDescriptionCard bids={displayBids} description={product.description} />
       {data.status === 'closed' &&
         (displayBids.length === 0 && data.seller_id === userId ? (

--- a/apps/web/widgets/auction-detail-card/ui/AuctionDescriptionCard.tsx
+++ b/apps/web/widgets/auction-detail-card/ui/AuctionDescriptionCard.tsx
@@ -1,10 +1,12 @@
 'use client';
 import { useState } from 'react';
 
+import { cn } from '@repo/ui/utils/cn';
+
 import { AuctionBidHistoryCard } from '@/features/auction/ui/AuctionBidHistoryCard';
 
 import { Bid } from '@/shared/types/db';
-import { cn } from '@repo/ui/utils/cn';
+
 import { auctionDescriptionCardStyle } from './styles/AuctionDescriptionCard.styles';
 
 export const AuctionDescriptionCard = ({
@@ -31,7 +33,7 @@ export const AuctionDescriptionCard = ({
               auctionDescriptionCardStyle.auctionDescriptionCardTabActiveStyle
           )}
         >
-          상품설명
+          상품 설명
         </div>
         <div
           onClick={() => setTab('bids')}
@@ -40,7 +42,7 @@ export const AuctionDescriptionCard = ({
             tab === 'bids' && auctionDescriptionCardStyle.auctionDescriptionCardTabActiveStyle
           )}
         >
-          입찰기록
+          최근 입찰
         </div>
       </div>
 
@@ -57,7 +59,9 @@ export const AuctionDescriptionCard = ({
               첫번째 입찰자가 되어보세요!
             </div>
           ) : (
-            sortedBids.map((bid) => <AuctionBidHistoryCard key={bid.bid_id} bid={bid} />)
+            sortedBids
+              .slice(0, 5)
+              .map((bid) => <AuctionBidHistoryCard key={bid.bid_id} bid={bid} />)
           )}
         </div>
       )}


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용
경매 상세 페이지의 입찰 기록의 수를 최근에 입찰 된 5개로 제한하고 최근 입찰로 문구 변경하였습니다.

## 🔧 변경 사항
- 입찰 기록 => 최근 입찰로 변경
- slice를 활용한 5개 item만 렌더링 되도록 변경

## 📸 스크린샷 (선택 사항)
<img width="470" height="907" alt="image" src="https://github.com/user-attachments/assets/4e3b4785-f91d-46c1-b5bb-1a3275375a49" />

## 📄 기타
