### PR TITLE
Refactor/icon #320

### DIFF
--- a/apps/web/features/auction-add/ui/AuctionImageUploader.tsx
+++ b/apps/web/features/auction-add/ui/AuctionImageUploader.tsx
@@ -2,10 +2,12 @@
 
 import React, { useRef } from 'react';
 
-import { IoIosAddCircleOutline, IoMdCloseCircle } from 'react-icons/io';
+import { CirclePlus, CircleX } from 'lucide-react';
 
 import { useAuctionImage } from '@/shared/api/client/auction/useAuctionImage';
+
 import { handleImageChange } from '../model/handlers';
+
 import { auctionImageUploaderStyle } from './styles/AuctionImageUploader.styles';
 
 interface AuctionImageUploaderProps {
@@ -31,7 +33,7 @@ export const AuctionImageUploader: React.FC<AuctionImageUploaderProps> = ({
   return (
     <div className={auctionImageUploaderStyle.auctionImageUploaderContainerStyle}>
       <div className={auctionImageUploaderStyle.imageUploaderStyle} onClick={handleImageClick}>
-        <IoIosAddCircleOutline className={auctionImageUploaderStyle.imageUploaderIconStyle} />
+        <CirclePlus className={auctionImageUploaderStyle.imageUploaderIconStyle} />
         <input
           ref={fileInputRef}
           type="file"
@@ -53,7 +55,7 @@ export const AuctionImageUploader: React.FC<AuctionImageUploaderProps> = ({
               onClick={() => handleRemoveImage(idx)}
               tabIndex={-1}
             >
-              <IoMdCloseCircle size={24} />
+              <CircleX size={24} fill="white" />
             </button>
           </div>
         ))}

--- a/apps/web/features/auction-add/ui/styles/AuctionImageUploader.styles.ts
+++ b/apps/web/features/auction-add/ui/styles/AuctionImageUploader.styles.ts
@@ -2,7 +2,7 @@ export const auctionImageUploaderStyle = {
   auctionImageUploaderContainerStyle: 'mb-1 flex items-start gap-2',
   imageUploaderStyle:
     'w-30 h-30 border-[var(--form-border)] flex shrink-0 cursor-pointer items-center justify-center rounded-md border',
-  imageUploaderIconStyle: 'text-neutral-40',
+  imageUploaderIconStyle: 'text-neutral-500',
 
   imagePreviewContainerStyle: 'flex max-w-[210px] flex-nowrap gap-2 overflow-x-auto',
   imagePreviewStyle:

--- a/apps/web/features/auction/ui/AuctionOverlay.tsx
+++ b/apps/web/features/auction/ui/AuctionOverlay.tsx
@@ -2,8 +2,8 @@
 import { useState } from 'react';
 
 import { Button } from '@repo/ui/design-system/base-components/Button/index';
+import { X } from 'lucide-react';
 import Link from 'next/link';
-import { IoMdClose } from 'react-icons/io';
 
 import { overlayStyle } from './styles/AuctionOverlay';
 
@@ -31,7 +31,7 @@ export const AuctionOverlay = ({
     >
       {/* 닫기 버튼 */}
       {isCanClose && (
-        <IoMdClose
+        <X
           className={overlayStyle.closeIconStyle}
           onClick={(e) => {
             e.stopPropagation();

--- a/apps/web/features/chat-room/ui/ChatRoomHeader.tsx
+++ b/apps/web/features/chat-room/ui/ChatRoomHeader.tsx
@@ -1,7 +1,9 @@
 'use client';
 
+import { MapPin } from 'lucide-react';
+
 import { ChatRoom } from '@/shared/types/chat';
-import { FaLocationDot } from 'react-icons/fa6';
+
 import { chatHeaderStyles } from '../styles/ChatRoomHeader.styles';
 
 interface Props {
@@ -30,7 +32,7 @@ export const ChatRoomHeader = ({ room, currentUserId }: Props) => {
 
       <div className={chatHeaderStyles.bottomSection}>
         <div className={chatHeaderStyles.locationWrapper}>
-          <FaLocationDot className={chatHeaderStyles.locationIcon} />
+          <MapPin className={chatHeaderStyles.locationIcon} />
           <span className="truncate">{room.seller_location}</span>
         </div>
 

--- a/apps/web/features/profile/ui/ProfileAvatarUpload.tsx
+++ b/apps/web/features/profile/ui/ProfileAvatarUpload.tsx
@@ -3,7 +3,7 @@
 import { useRef } from 'react';
 
 import { Avatar } from '@repo/ui/design-system/base-components/Avatar/index';
-import { FaCamera } from 'react-icons/fa6';
+import { Camera } from 'lucide-react';
 
 interface AvatarUploadProps {
   username: string;
@@ -61,9 +61,9 @@ export const ProfileAvatarUpload = ({
           onClick={imageClick}
           role="button"
           aria-label="camera"
-          className="border-3 absolute -right-[7px] bottom-0 inline-block cursor-pointer rounded-full border-solid border-white bg-neutral-500 p-1"
+          className="absolute -right-[7px] bottom-0 inline-block cursor-pointer rounded-full bg-neutral-300 p-1"
         >
-          <FaCamera className="size-3.5 text-white" />
+          <Camera size={20} color="white" />
         </p>
       </div>
     </div>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -31,7 +31,6 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-hot-toast": "^2.5.2",
-    "react-icons": "5.5.0",
     "react-intersection-observer": "^9.16.0",
     "swiper": "^11.2.8",
     "uuid": "^11.1.0",
@@ -40,6 +39,7 @@
     "zustand": "^5.0.5"
   },
   "devDependencies": {
+    "@next/bundle-analyzer": "^14.2.5",
     "@next/eslint-plugin-next": "^15.3.0",
     "@repo/eslint-config": "workspace:*",
     "@repo/tailwind-config": "workspace:*",
@@ -52,17 +52,16 @@
     "@types/react-dom": "^19.1.1",
     "@types/uuid": "^10.0.0",
     "@types/web-push": "^3.6.4",
-    "@next/bundle-analyzer": "^14.2.5",
     "@vitejs/plugin-react": "^4.6.0",
     "@vitest/coverage-v8": "^3.2.3",
     "autoprefixer": "^10.4.20",
+    "cross-env": "^7.0.3",
     "cypress": "^14.5.0",
     "eslint": "^9.28.0",
     "jsdom": "^26.1.0",
     "postcss": "^8.5.3",
     "tailwindcss": "^4.1.5",
     "typescript": "5.8.2",
-    "vitest": "^3.2.3",
-    "cross-env": "^7.0.3"
+    "vitest": "^3.2.3"
   }
 }

--- a/apps/web/widgets/auction-detail-card/ui/AuctionDetailCard.tsx
+++ b/apps/web/widgets/auction-detail-card/ui/AuctionDetailCard.tsx
@@ -2,15 +2,15 @@
 
 import { Button } from '@repo/ui/design-system/base-components/Button/index';
 import { formatPriceNumber } from '@repo/ui/utils/formatNumberWithComma';
+import { Minus, Plus } from 'lucide-react';
 import Link from 'next/link';
 import toast from 'react-hot-toast';
-import { FaMinus, FaPlus } from 'react-icons/fa';
 
 import { useDeleteAuction } from '@/shared/api/client/auction/useDeleteAuction';
 import { useAuthStore } from '@/shared/stores/auth';
+import { useModalStore } from '@/shared/stores/modal';
 
 import { auctionDetailCardStyle } from './styles/AuctionDetailCard.styles';
-import { useModalStore } from '@/shared/stores/modal';
 
 interface AuctionDetailCardProps {
   currentBidCost: number;
@@ -106,11 +106,11 @@ export const AuctionDetailCard = ({
         </div>
         <div className={auctionDetailCardStyle.auctionDetailCardBidControlStyle}>
           <Button variants="outline" onClick={onMinus} disabled={status !== 'in_progress'}>
-            <FaMinus />
+            <Minus size={20} />
           </Button>
           {formatPriceNumber(bidCost)}원
           <Button variants="outline" onClick={onPlus} disabled={status !== 'in_progress'}>
-            <FaPlus />
+            <Plus size={20} />
           </Button>
         </div>
       </div>

--- a/apps/web/widgets/authentication/LogoutButton.tsx
+++ b/apps/web/widgets/authentication/LogoutButton.tsx
@@ -2,8 +2,8 @@
 
 import { useEffect } from 'react';
 
+import { LogOut } from 'lucide-react';
 import toast from 'react-hot-toast';
-import { MdLogout } from 'react-icons/md';
 
 import { useLogout } from '@/shared/hooks/useLogout';
 import { useModalStore } from '@/shared/stores/modal';
@@ -36,7 +36,7 @@ export const LogoutButton = () => {
   return (
     <>
       <div onClick={handleLogout} className={logoutSectionStyles.nav}>
-        <MdLogout className={logoutSectionStyles.logoutIcon} aria-hidden="true" />
+        <LogOut className={logoutSectionStyles.logoutIcon} aria-hidden="true" />
         <span className={navigationStyles.link}>로그아웃</span>
       </div>
     </>

--- a/apps/web/widgets/footer/ui/Footer.tsx
+++ b/apps/web/widgets/footer/ui/Footer.tsx
@@ -1,17 +1,15 @@
 'use client';
+import { ForwardRefExoticComponent, RefAttributes } from 'react';
+
 import { cn } from '@repo/ui/utils/cn';
+import { CirclePlus, Flame, House, LucideProps, MessageCircleMore, UserRound } from 'lucide-react';
 import { usePathname, useRouter } from 'next/navigation';
-import { IconType } from 'react-icons';
-import { GoSearch } from 'react-icons/go';
-import { IoIosAddCircleOutline } from 'react-icons/io';
-import { IoChatbubbleEllipsesOutline, IoHomeOutline } from 'react-icons/io5';
-import { LuUserRound } from 'react-icons/lu';
 
 import { footerStyles as styles } from '../styles/footer.styles';
 interface NavigationItem {
   label: string;
   href: string;
-  icon: IconType;
+  icon: ForwardRefExoticComponent<Omit<LucideProps, 'ref'> & RefAttributes<SVGSVGElement>>;
 }
 
 export const Footer = () => {
@@ -19,11 +17,11 @@ export const Footer = () => {
   const router = useRouter();
 
   const items: NavigationItem[] = [
-    { label: '홈', href: '/main', icon: IoHomeOutline },
-    { label: '핫딜', href: '/hotdeal', icon: GoSearch },
-    { label: '등록', href: '/auction/auction-add', icon: IoIosAddCircleOutline },
-    { label: '대화', href: '/chat', icon: IoChatbubbleEllipsesOutline },
-    { label: '프로필', href: '/profile', icon: LuUserRound },
+    { label: '홈', href: '/main', icon: House },
+    { label: '핫딜', href: '/hotdeal', icon: Flame },
+    { label: '등록', href: '/auction/auction-add', icon: CirclePlus },
+    { label: '대화', href: '/chat', icon: MessageCircleMore },
+    { label: '프로필', href: '/profile', icon: UserRound },
   ];
 
   return (

--- a/apps/web/widgets/header/styles/header.styles.ts
+++ b/apps/web/widgets/header/styles/header.styles.ts
@@ -6,12 +6,12 @@ export const headerStyles = {
   // 뒤로가기 버튼
   backButton: {
     wrapper: 'text-neutral-700',
-    icon: 'size-4',
+    icon: 'size-6',
   },
 
   // 버튼 영역
   buttonArea: {
-    container: 'grow text-right',
+    container: 'flex justify-end',
     notificationButton: ' px-2',
     locationButton: 'px-2',
     searchButton: 'px-2',

--- a/apps/web/widgets/header/ui/Header.tsx
+++ b/apps/web/widgets/header/ui/Header.tsx
@@ -5,6 +5,8 @@ import { ArrowLeft, Bell, Search } from 'lucide-react';
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
 
+import { useAuthStore } from '@/shared/stores/auth';
+
 import { useModalStore } from '../../../shared/stores/modal';
 import { headerStyles as styles } from '../styles/header.styles';
 
@@ -12,6 +14,7 @@ export const Header = () => {
   const pathname = usePathname();
   const router = useRouter();
   const { setOpenModal } = useModalStore();
+  const { userId } = useAuthStore();
 
   const noBackButtonRoutes = ['/main'];
   const showBackButton = !noBackButtonRoutes.includes(pathname);
@@ -39,22 +42,30 @@ export const Header = () => {
         )}
       </div>
       <div className={styles.buttonArea.container}>
-        <Link href="/auction/auction-list">
-          <Button variants="ghost" size="thinMd" className={styles.buttonArea.searchButton}>
-            {/* 5. 검색 아이콘에 조건부 클래스를 적용합니다. */}
-            <Search className={`${styles.buttonArea.icon} ${mainPageTextClass}`} />
-          </Button>
-        </Link>
+        {pathname !== '/hotdeal' && (
+          <Link href="/auction/auction-list">
+            <Button variants="ghost" size="thinMd" className={styles.buttonArea.searchButton}>
+              {/* 5. 검색 아이콘에 조건부 클래스를 적용합니다. */}
+              <Search className={`${styles.buttonArea.icon} ${mainPageTextClass}`} />
+            </Button>
+          </Link>
+        )}
 
-        <Button
-          variants="ghost"
-          size="thinMd"
-          onClick={() => setOpenModal('notification')}
-          className={styles.buttonArea.notificationButton}
-        >
-          {/* 4. 알림 아이콘에 조건부 클래스를 적용합니다. */}
-          <Bell className={`${styles.buttonArea.icon} ${mainPageTextClass}`} />
-        </Button>
+        {userId ? (
+          <Button
+            variants="ghost"
+            size="thinMd"
+            onClick={() => setOpenModal('notification')}
+            className={styles.buttonArea.notificationButton}
+          >
+            {/* 4. 알림 아이콘에 조건부 클래스를 적용합니다. */}
+            <Bell className={`${styles.buttonArea.icon} ${mainPageTextClass}`} />
+          </Button>
+        ) : (
+          <Button variants="ghost" size="thinMd" onClick={() => router.replace('/login')}>
+            로그인
+          </Button>
+        )}
       </div>
     </header>
   );

--- a/apps/web/widgets/header/ui/Header.tsx
+++ b/apps/web/widgets/header/ui/Header.tsx
@@ -39,6 +39,13 @@ export const Header = () => {
         )}
       </div>
       <div className={styles.buttonArea.container}>
+        <Link href="/auction/auction-list">
+          <Button variants="ghost" size="thinMd" className={styles.buttonArea.searchButton}>
+            {/* 5. 검색 아이콘에 조건부 클래스를 적용합니다. */}
+            <Search className={`${styles.buttonArea.icon} ${mainPageTextClass}`} />
+          </Button>
+        </Link>
+
         <Button
           variants="ghost"
           size="thinMd"
@@ -48,13 +55,6 @@ export const Header = () => {
           {/* 4. 알림 아이콘에 조건부 클래스를 적용합니다. */}
           <Bell className={`${styles.buttonArea.icon} ${mainPageTextClass}`} />
         </Button>
-
-        <Link href="/auction/auction-list">
-          <Button variants="ghost" size="thinMd" className={styles.buttonArea.searchButton}>
-            {/* 5. 검색 아이콘에 조건부 클래스를 적용합니다. */}
-            <Search className={`${styles.buttonArea.icon} ${mainPageTextClass}`} />
-          </Button>
-        </Link>
       </div>
     </header>
   );

--- a/apps/web/widgets/modal/styles/notificationModal.styles.ts
+++ b/apps/web/widgets/modal/styles/notificationModal.styles.ts
@@ -5,9 +5,6 @@ export const notificationModalStyles = {
   // 모달 콘텐츠
   content: 'h-[500px] w-[340px] bg-white p-4',
 
-  // 로딩 컨테이너 (추가)
-  loading: 'flex items-center justify-center p-8',
-
   // 빈 상태 메시지
   emptyMessage: 'text-center py-8',
 

--- a/apps/web/widgets/modal/ui/NotificationModal.tsx
+++ b/apps/web/widgets/modal/ui/NotificationModal.tsx
@@ -6,16 +6,16 @@ import {
   ModalContent,
   ModalHeader,
 } from '@repo/ui/design-system/base-components/Modal/index';
-import { Gavel } from 'lucide-react';
+import { Hammer } from 'lucide-react';
 import { useRouter } from 'next/navigation';
-import { AiOutlineLoading3Quarters } from 'react-icons/ai';
 
+import { LoadingSpinner } from '@/widgets/loading-spiner';
 import { NotificationSettings } from '@/widgets/profile/ui/NotificationSettings';
 
 import { useNotificationList } from '@/shared/api/client/notification/useNotificationList';
+import { useModalStore } from '@/shared/stores/modal';
 import { NotificationItem } from '@/shared/types/notification';
 
-import { useModalStore } from '../../../shared/stores/modal';
 import { notificationModalStyles } from '../styles/notificationModal.styles';
 
 import { NotificationModalItem } from './NotificationModalItem';
@@ -31,8 +31,8 @@ const NotificationModal = () => {
         <ModalHeader title="알림" onClose={closeModal} />
         <NotificationSettings />
         {isLoading ? (
-          <div className={notificationModalStyles.loading}>
-            <AiOutlineLoading3Quarters className="animate-spin" />
+          <div className="flex h-full items-center justify-center">
+            <LoadingSpinner />
           </div>
         ) : (
           <>
@@ -42,7 +42,7 @@ const NotificationModal = () => {
               <>
                 <ItemBadge className={notificationModalStyles.sectionBadge}>
                   <span className={notificationModalStyles.sectionIcon}>
-                    <Gavel className="mr-1 size-5" />
+                    <Hammer className="mr-1 size-5" />
                   </span>
                   <h3>{items.length}개의 경매가 있습니다.</h3>
                 </ItemBadge>

--- a/apps/web/widgets/profile/styles/pointsHistory.styles.ts
+++ b/apps/web/widgets/profile/styles/pointsHistory.styles.ts
@@ -11,12 +11,6 @@ export const pointsHistoryListStyles = {
   filterContainer: 'mb-2 w-full text-right',
   filterSelect: 'text-neutral-70 my-2 w-1/2 rounded-sm p-1 shadow-md',
 
-  // 로딩 상태
-  loading: {
-    container: 'flex items-center justify-center p-8',
-    spinner: 'animate-spin',
-  },
-
   // 빈 상태 메시지
   emptyMessage: 'py-8 text-center text-gray-500',
 

--- a/apps/web/widgets/profile/styles/useProfileCard.styles.ts
+++ b/apps/web/widgets/profile/styles/useProfileCard.styles.ts
@@ -10,7 +10,7 @@ export const userProfileCardStyles = {
     wrapper: 'w-[220px]',
     header: 'flex items-end justify-between mb-1',
     username: 'text-base font-semibold',
-    settingsIcon: 'size-4',
+    settingsIcon: 'size-5 top-1',
     email: 'mb-2 mb-1 text-xs not-italic',
   },
 

--- a/apps/web/widgets/profile/ui/Navigation.tsx
+++ b/apps/web/widgets/profile/ui/Navigation.tsx
@@ -1,7 +1,8 @@
+import { ChevronRight } from 'lucide-react';
 import Link from 'next/link';
-import { IoChevronForward } from 'react-icons/io5';
 
 import { NavigationItem } from '@/shared/types/profile';
+
 import { navigationStyles as styles } from '../styles/navigation.styles';
 
 interface NavigationProps {
@@ -17,7 +18,7 @@ export const Navigation = ({ title, items }: NavigationProps) => {
           <li key={item.href}>
             <Link href={item.href} className={styles.link}>
               <span className={styles.label}>{item.label}</span>
-              <IoChevronForward className={styles.chevronIcon} aria-hidden="true" />
+              <ChevronRight className={styles.chevronIcon} aria-hidden="true" />
             </Link>
             {index < items.length - 1 && <hr className={styles.divider} aria-hidden="true" />}
           </li>

--- a/apps/web/widgets/profile/ui/PointsHistoryList.tsx
+++ b/apps/web/widgets/profile/ui/PointsHistoryList.tsx
@@ -1,12 +1,14 @@
 'use client';
+import { useState } from 'react';
+
 import { Item, ItemContent, ItemTitle } from '@repo/ui/design-system/base-components/Item/index';
+import { format } from 'date-fns';
+
+import { LoadingSpinner } from '@/widgets/loading-spiner';
 
 import { usePointsHistory } from '@/shared/api/client/point/usePointsHistory';
-import { AiOutlineLoading3Quarters } from 'react-icons/ai';
-import { pointsHistoryListStyles as styles } from '../styles/pointsHistory.styles';
 
-import { format } from 'date-fns';
-import { useState } from 'react';
+import { pointsHistoryListStyles as styles } from '../styles/pointsHistory.styles';
 
 export type PointHistoryData = {
   id: string;
@@ -44,8 +46,8 @@ export const PointsHistoryList = () => {
 
   if (isLoading) {
     return (
-      <div className={styles.loading.container}>
-        <AiOutlineLoading3Quarters className={styles.loading.spinner} />
+      <div className="flex h-full items-center justify-center">
+        <LoadingSpinner />
       </div>
     );
   }

--- a/apps/web/widgets/profile/ui/UserProfileCard.tsx
+++ b/apps/web/widgets/profile/ui/UserProfileCard.tsx
@@ -1,11 +1,12 @@
 import { Avatar } from '@repo/ui/design-system/base-components/Avatar/index';
 import { LocationInfo } from '@repo/ui/design-system/base-components/LocationInfo/index';
+import { Settings } from 'lucide-react';
 import Link from 'next/link';
-import { IoSettingsOutline } from 'react-icons/io5';
 
 import { getGradeIcon } from '@/shared/lib/points/getGradeIcon';
 import { getCacheBustingUrl } from '@/shared/lib/utils/avatar';
 import { UserProfileType } from '@/shared/types/profile';
+
 import { userProfileCardStyles as styles } from '../styles/useProfileCard.styles';
 
 export const UserProfileCard = ({ user }: { user: UserProfileType }) => {
@@ -25,7 +26,7 @@ export const UserProfileCard = ({ user }: { user: UserProfileType }) => {
           <header className={styles.userInfo.header}>
             <h3 className={styles.userInfo.username}>{user.username}</h3>
             <Link href="/profile/update">
-              <IoSettingsOutline className={styles.userInfo.settingsIcon} aria-hidden="true" />
+              <Settings className={styles.userInfo.settingsIcon} aria-hidden="true" />
             </Link>
           </header>
           <address className={styles.userInfo.email}>{user.email}</address>

--- a/apps/web/widgets/scroll-button/ScrollButton.styles.ts
+++ b/apps/web/widgets/scroll-button/ScrollButton.styles.ts
@@ -1,5 +1,5 @@
 export const ScrollButtonStyle = {
   container: 'z-30 sticky bottom-2 right-0 float-right',
   button:
-    'rounded-full bg-[var(--button-primary-bg)] p-4 text-[var(--button-primary-text)] hover:bg-[var(--button-primary-bg-hover)]',
+    'rounded-full bg-[var(--button-primary-bg)] p-2.5 text-[var(--button-primary-text)] hover:bg-[var(--button-primary-bg-hover)]',
 };

--- a/apps/web/widgets/scroll-button/ScrollButton.tsx
+++ b/apps/web/widgets/scroll-button/ScrollButton.tsx
@@ -1,13 +1,15 @@
 'use client';
 
-import { usePathname } from 'next/navigation';
 import { useEffect, useState } from 'react';
-import { FaChevronUp } from 'react-icons/fa6';
+
+import { ChevronUp } from 'lucide-react';
+import { usePathname } from 'next/navigation';
+
 import { ScrollButtonStyle } from './ScrollButton.styles';
 
 const SCROLL_THRESHOLD = 0; // 사용자가 수정한 스크롤 감지 임계값 유지
 
-export function ScrollButton() {
+export const ScrollButton = () => {
   const pathname = usePathname();
   const [isVisible, setIsVisible] = useState(false);
   const [isMounted, setIsMounted] = useState(false);
@@ -61,9 +63,9 @@ export function ScrollButton() {
     <div className={ScrollButtonStyle.container}>
       {isVisible && (
         <div onClick={scrollToTop} className={ScrollButtonStyle.button} aria-label="Go to top">
-          <FaChevronUp />
+          <ChevronUp size={20} />
         </div>
       )}
     </div>
   );
-}
+};

--- a/apps/web/widgets/search/ui/SearchInput.tsx
+++ b/apps/web/widgets/search/ui/SearchInput.tsx
@@ -2,9 +2,8 @@
 import { Dispatch, SetStateAction, useState } from 'react';
 
 import { Button } from '@repo/ui/design-system/base-components/Button/index';
+import { Search, X } from 'lucide-react';
 import { useRouter } from 'next/navigation';
-import { GoSearch } from 'react-icons/go';
-import { IoIosClose } from 'react-icons/io';
 
 import { Input } from '../../../../../packages/ui/src/design-system/base-components/Input/Input';
 import { searchInputStyles } from '../styles/searchInput.styles';
@@ -41,7 +40,7 @@ export const SearchInput = ({ setCategory }: Props) => {
             type="submit"
             className={`${searchInputStyles.button.base}`}
           >
-            <GoSearch className={searchInputStyles.icon} />
+            <Search className={searchInputStyles.icon} />
           </Button>
         </div>
       </form>
@@ -54,7 +53,7 @@ export const SearchInput = ({ setCategory }: Props) => {
         className={searchInputStyles.resetSearch}
       >
         검색어 초기화
-        <IoIosClose />
+        <X size={20} />
       </div>
     </>
   );

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -29,7 +29,6 @@
     "clsx": "^2.1.1",
     "lucide-react": "^0.522.0",
     "next": "^15.2.3",
-    "react-icons": "^5.5.0",
     "swiper": "^11.2.8",
     "tailwind-merge": "^3.3.0",
     "tw-animate-css": "^1.3.4"

--- a/packages/ui/src/design-system/base-components/CustomCheckbox/CustomCheckbox.tsx
+++ b/packages/ui/src/design-system/base-components/CustomCheckbox/CustomCheckbox.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { IoCheckmark, IoChevronForward } from 'react-icons/io5';
+import { Check, ChevronRight } from 'lucide-react';
 
 export interface CustomCheckboxProps {
   id: string;
@@ -34,7 +34,7 @@ export const CustomCheckbox = ({
         {/* 커스텀 체크박스 UI */}
         <div className="relative flex h-6 w-6 items-center justify-center rounded border-2 border-gray-300 bg-white transition-all peer-checked:border-indigo-600 peer-checked:bg-indigo-600">
           {/* [핵심 수정] CSS 투명도 대신, checked 상태에 따라 아이콘을 직접 렌더링합니다. */}
-          {checked && <IoCheckmark className="h-5 w-5 text-white" />}
+          {checked && <Check className="h-5 w-5 text-gray-400" />}
         </div>
 
         {/* 레이블 텍스트 */}
@@ -55,7 +55,7 @@ export const CustomCheckbox = ({
           className="text-gray-400 hover:text-gray-600"
           aria-label={`${label} 상세보기`}
         >
-          <IoChevronForward className="h-6 w-6" />
+          <ChevronRight className="h-6 w-6" />
         </button>
       )}
     </div>

--- a/packages/ui/src/design-system/base-components/Input/Input.tsx
+++ b/packages/ui/src/design-system/base-components/Input/Input.tsx
@@ -1,5 +1,5 @@
+import { Eye, EyeOff, Lock, Mail } from 'lucide-react';
 import React, { forwardRef, useId, useState } from 'react';
-import { MdEmail, MdLock, MdVisibility, MdVisibilityOff } from 'react-icons/md';
 import { cn } from '../../../utils/cn';
 import { inputStyle } from './Input.styles';
 
@@ -57,10 +57,10 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
 
     const renderLeftIcon = () => {
       if (leftIcon === 'email') {
-        return <MdEmail className={inputStyle.inputIconStyle} />;
+        return <Mail className={inputStyle.inputIconStyle} />;
       }
       if (leftIcon === 'password') {
-        return <MdLock className={inputStyle.inputIconStyle} />;
+        return <Lock className={inputStyle.inputIconStyle} />;
       }
       return null;
     };
@@ -125,9 +125,9 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
                 aria-label={showPassword ? '비밀번호 숨기기' : '비밀번호 보기'}
               >
                 {showPassword ? (
-                  <MdVisibilityOff className={inputStyle.inputIconStyle} />
+                  <Eye className={inputStyle.inputIconStyle} />
                 ) : (
-                  <MdVisibility className={inputStyle.inputIconStyle} />
+                  <EyeOff className={inputStyle.inputIconStyle} />
                 )}
               </button>
             )}

--- a/packages/ui/src/design-system/base-components/LocationInfo/LocationInfo.styles.ts
+++ b/packages/ui/src/design-system/base-components/LocationInfo/LocationInfo.styles.ts
@@ -1,5 +1,5 @@
 export const locationInfoStyle = {
   locationInfoBasicStyle: 'flex items-center justify-start text-xs',
-  locationInfoIconStyle: 'mr-1 size-4 text-pink-500',
+  locationInfoIconStyle: 'mr-1 size-4',
   locationInfoTextStyle: 'truncate',
 };

--- a/packages/ui/src/design-system/base-components/LocationInfo/LocationInfo.tsx
+++ b/packages/ui/src/design-system/base-components/LocationInfo/LocationInfo.tsx
@@ -1,4 +1,4 @@
-import { FaMapMarkerAlt } from 'react-icons/fa';
+import { MapPin } from 'lucide-react';
 import { locationInfoStyle } from './LocationInfo.styles';
 
 interface LocationInfoProps {
@@ -13,7 +13,7 @@ const LocationInfo = ({ address, addressDetail }: LocationInfoProps) => {
 
   return (
     <div className={locationInfoStyle.locationInfoBasicStyle}>
-      <FaMapMarkerAlt className={locationInfoStyle.locationInfoIconStyle} />
+      <MapPin className={locationInfoStyle.locationInfoIconStyle} />
       <div className={locationInfoStyle.locationInfoTextStyle}>
         {safeAddress}
         {safeDetail}

--- a/packages/ui/src/design-system/base-components/Modal/Modal.tsx
+++ b/packages/ui/src/design-system/base-components/Modal/Modal.tsx
@@ -1,5 +1,5 @@
 import { cn } from '@repo/ui/utils/cn';
-import { IoMdClose } from 'react-icons/io';
+import { X } from 'lucide-react';
 import { Button } from '../Button';
 import { modalStyle } from './Modal.styles';
 
@@ -65,7 +65,7 @@ const ModalCloseButton = ({ onClose, className = '' }: ModalCloseButtonProps) =>
       className={cn(modalStyle.modalCloseButtonStyle, className)}
       onClick={onClose}
     >
-      <IoMdClose className={modalStyle.modalCloseButtonIconStyle} />
+      <X className={modalStyle.modalCloseButtonIconStyle} />
     </Button>
   );
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -226,9 +226,6 @@ importers:
       react-hot-toast:
         specifier: ^2.5.2
         version: 2.5.2(react-dom@19.1.0)(react@19.1.0)
-      react-icons:
-        specifier: 5.5.0
-        version: 5.5.0(react@19.1.0)
       react-intersection-observer:
         specifier: ^9.16.0
         version: 9.16.0(react-dom@19.1.0)(react@19.1.0)
@@ -394,9 +391,6 @@ importers:
       react-dom:
         specifier: ^19.1.0
         version: 19.1.0(react@19.1.0)
-      react-icons:
-        specifier: ^5.5.0
-        version: 5.5.0(react@19.1.0)
       swiper:
         specifier: ^11.2.8
         version: 11.2.8
@@ -10630,14 +10624,6 @@ packages:
       goober: 2.1.16(csstype@3.1.3)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
-    dev: false
-
-  /react-icons@5.5.0(react@19.1.0):
-    resolution: {integrity: sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==}
-    peerDependencies:
-      react: '*'
-    dependencies:
-      react: 19.1.0
     dev: false
 
   /react-intersection-observer@9.16.0(react-dom@19.1.0)(react@19.1.0):


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용
- react-icons lucide icon으로 대체 
- react-icons 라이브러리 삭제 
- 헤더 ui 로그인 여부에 따라 변경 (아래 사진 참고 부탁드립니다.)
## 🔧 변경 사항

## 📸 스크린샷 (선택 사항)
로그인 하지 않았을 때
<img width="369" height="67" alt="{081D5A3A-D777-4EEB-A230-B7ABC70DDE23}" src="https://github.com/user-attachments/assets/63c6ef37-944a-4db0-9599-cea4af561059" />

핫딜페이지에서는 검색 버튼 제외 
<img width="378" height="61" alt="{F91BA75C-E0B8-40BF-961B-8F9EE44E5B59}" src="https://github.com/user-attachments/assets/bf04234a-18c5-4873-b45a-11ffd911a768" />

로그인 한 상태 
<img width="368" height="65" alt="{4369690D-9460-4174-8B63-A3632AB4129D}" src="https://github.com/user-attachments/assets/cc011927-5726-44cd-85cc-5d014a3e39ee" />


## 📄 기타
