### PR TITLE
fix: 경매 시간이 하루 차이인 경매가 등록이 안되는 현상 수정

### DIFF
--- a/apps/web/shared/lib/validators/auctionAddSchema.ts
+++ b/apps/web/shared/lib/validators/auctionAddSchema.ts
@@ -83,9 +83,9 @@ export const auctionAddSchema = z
     (data) => {
       const startDate = new Date(data.startDate);
       const endDate = new Date(data.endDate);
-      const differenceInMs = endDate.getTime() - startDate.getTime();
-      const oneDayInMs = 24 * 60 * 60 * 1000;
-      return differenceInMs >= oneDayInMs;
+      startDate.setHours(0, 0, 0, 0);
+      endDate.setHours(0, 0, 0, 0);
+      return endDate >= startDate;
     },
     {
       message: '경매 종료일은 시작일 이후여야 합니다.',


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용
경매 등록 스키마에서 경매 시작시간과 종료시간의 차이를 ms단위로 비교해서 시작시간이 미세하게 변경되어 24시간에 충족되지 않아 발생한 버그를 수정했습니다.
이제는 각 시간의 날짜만 비교하여 진행합니다.

## 🔧 변경 사항
- 경매 등록 스키마 변경
## 📸 스크린샷 (선택 사항)

## 📄 기타
