### PR TITLE
fix: 사용자가 구독한 모든 디바이스에 푸시 알림

### DIFF
--- a/apps/web/shared/types/notification/index.ts
+++ b/apps/web/shared/types/notification/index.ts
@@ -11,7 +11,7 @@ export interface BaseNotification {
   title: string;
   body: string;
   sent_at: string;
-  delivery_status: 'not_subscribe' | 'sent' | 'failed';
+  delivery_status: 'not_subscribe' | 'sent' | 'failed' | 'partial';
 }
 
 export interface AuctionOutbidNotification extends BaseNotification {


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용
- 사용자가 구독한 모든 디바이스에 푸시 알림 보냅니다. (배포 환경에서 테스트 예정)
기존 (단일 디바이스, 마지막에 구독한 디바이스에만 알림 옴)
```
// 기존: .single()로 하나의 구독만 가져옴
const { data: subscriptionData, error: subscriptionError } = await adminClient
  .from('push_subscriptions')
  .select('endpoint, p256dh, auth')
  .eq('user_id', config.userId)
  .single(); // 🚨 문제: 첫 번째 구독만 선택
```

변경 후 
```
// 개선: 모든 활성 구독 조회
const { data: subscriptionsData, error: subscriptionError } = await adminClient
  .from('push_subscriptions')
  .select('endpoint, p256dh, auth, user_agent')
  .eq('user_id', config.userId)
  .eq('is_active', true); // 활성 구독만 선택
```

병렬 푸시
```
// ✅ 개선: Promise.allSettled로 모든 기기에 병렬 발송
const pushResults = await Promise.allSettled(
  subscriptionsData.map(async (subscription) => {
    try {
      // 각 기기별로 푸시 발송
      await webpush.sendNotification(pushSubscription, pushPayload);
      return { success: true, endpoint: subscription.endpoint };
    } catch (pushError) {
      // 실패 처리 및 만료된 구독 비활성화
      return { success: false, endpoint: subscription.endpoint, error: pushError };
    }
  })
);
```

모든 기기에 web-push를 한 뒤, 실제 알림 내역에는 하나의 알림만 저장
## 🔧 변경 사항

## 📸 스크린샷 (선택 사항)

## 📄 기타
