### PR TITLE
[refactor]: 경매 이미지 최적화, 경매 등록 관련 로직 수정 및 전체 로딩스피너 적용

### DIFF
--- a/apps/web/app/(main)/auction/[auctionId]/auction-detail/page.tsx
+++ b/apps/web/app/(main)/auction/[auctionId]/auction-detail/page.tsx
@@ -11,6 +11,7 @@ import {
   AuctionSellerProfile,
 } from '@/widgets/auction-detail-card';
 import { ImageBanner } from '@/widgets/image-banner';
+import { LoadingSpinner } from '@/widgets/loading-spiner';
 
 import { useAuctionBidState } from '@/features/auction-detail/model/useAuctionBidState';
 import { AuctionOverlay } from '@/features/auction/ui/AuctionOverlay';
@@ -48,7 +49,12 @@ const Page = () => {
     }
   }, [data]);
 
-  if (isLoading) return <div>로딩 중...</div>;
+  if (isLoading)
+    return (
+      <div className="flex h-full w-full items-center justify-center">
+        <LoadingSpinner />
+      </div>
+    );
   if (error) return <div>에러: {error.message}</div>;
   if (!data) return <div>데이터가 없습니다.</div>;
 

--- a/apps/web/app/(main)/auction/auction-list/page.tsx
+++ b/apps/web/app/(main)/auction/auction-list/page.tsx
@@ -6,6 +6,7 @@ import { Category } from '@repo/ui/design-system/base-components/Category/index'
 import { useInView } from 'react-intersection-observer';
 
 import { AuctionListings } from '@/widgets/auction-listings/ui/AuctionListings';
+import { LoadingSpinner } from '@/widgets/loading-spiner';
 import { SearchInput } from '@/widgets/search';
 
 import { useAuctionList } from '@/shared/api/client/auction/useAuctionList';
@@ -46,7 +47,11 @@ const Page = () => {
   }
 
   if (isLoading) {
-    return <div className="my-8">경매 목록을 불러오는 중...</div>;
+    return (
+      <div className="flex h-full w-full items-center justify-center">
+        <LoadingSpinner />
+      </div>
+    );
   }
   if (isError) {
     return <div className="my-8 text-red-500">경매 목록을 불러오지 못했습니다.</div>;
@@ -74,7 +79,11 @@ const Page = () => {
       </select>
       <AuctionListings listData={filteredList} />
       <div ref={ref} style={{ height: '1px' }} />
-      {isFetchingNextPage && <div className="my-8">더 많은 경매를 불러오는 중...</div>}
+      {isFetchingNextPage && (
+        <div>
+          <LoadingSpinner />
+        </div>
+      )}
     </main>
   );
 };

--- a/apps/web/app/(main)/auction/my-listings/page.tsx
+++ b/apps/web/app/(main)/auction/my-listings/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 
+import { LoadingSpinner } from '@/widgets/loading-spiner';
 import { MyListings } from '@/widgets/my-listings/ui/MyListings';
 
 import { useMyListings } from '@/shared/api/client/auction/useMyListings';
@@ -15,7 +16,11 @@ const Page = () => {
   const { data: listings, isLoading, isError } = useMyListings(userId!, filter);
 
   if (isLoading) {
-    return <div>판매 물품 불러오는 중...</div>;
+    return (
+      <div className="flex h-full w-full items-center justify-center">
+        <LoadingSpinner />
+      </div>
+    );
   }
 
   if (isError) {

--- a/apps/web/app/(main)/auction/my-participated/page.tsx
+++ b/apps/web/app/(main)/auction/my-participated/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { LoadingSpinner } from '@/widgets/loading-spiner';
 import { MyParticipatedAuctions } from '@/widgets/my-participated/ui/MyParticipatedAuctions';
 
 import { useMyParticipatedAuction } from '@/shared/api/client/auction/useMyParticipatedAuctions';
@@ -12,7 +13,11 @@ const Page = () => {
   const { data: listings, isLoading, isError } = useMyParticipatedAuction(userId!);
 
   if (isLoading) {
-    return <div>참여 경매 목록 불러오는 중...</div>;
+    return (
+      <div className="flex h-full w-full items-center justify-center">
+        <LoadingSpinner />
+      </div>
+    );
   }
 
   if (isError) {

--- a/apps/web/app/(main)/auction/my-won-auctions/page.tsx
+++ b/apps/web/app/(main)/auction/my-won-auctions/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { LoadingSpinner } from '@/widgets/loading-spiner';
 import { MyWonAuctions } from '@/widgets/my-won-auctions/ui/MyWonAuctions';
 
 import { useMyWonAuctions } from '@/shared/api/client/auction/useMyWonAuctions';
@@ -12,7 +13,11 @@ const Page = () => {
   const { data: listings, isLoading, isError } = useMyWonAuctions(userId!);
 
   if (isLoading) {
-    return <div>낙찰된 경매 목록 불러오는 중...</div>;
+    return (
+      <div className="flex h-full w-full items-center justify-center">
+        <LoadingSpinner />
+      </div>
+    );
   }
 
   if (isError) {

--- a/apps/web/app/(main)/hotdeal/[hotdealId]/detail/page.tsx
+++ b/apps/web/app/(main)/hotdeal/[hotdealId]/detail/page.tsx
@@ -82,8 +82,8 @@ export default function Page({ params }: { params: Promise<{ hotdealId: string }
       <HotdealInfoCard data={data} countdown={countdown} />
 
       <Button
-        variants="custom"
-        className="bg-primary-500 hover:bg-primary-600 sticky bottom-1 text-white transition-colors"
+        variants="primary"
+        className="sticky bottom-1"
         size="thinLg"
         onClick={handlePurchase}
         disabled={status !== 'ACTIVE' || purchaseMutation.isPending}

--- a/apps/web/app/(no-footer)/chat/[roomId]/page.tsx
+++ b/apps/web/app/(no-footer)/chat/[roomId]/page.tsx
@@ -2,12 +2,14 @@
 
 import { useParams } from 'next/navigation';
 
+import { LoadingSpinner } from '@/widgets/loading-spiner';
+
 import { ChatInput } from '@/features/chat-room/ui/ChatInput';
 import { ChatMessages } from '@/features/chat-room/ui/ChatMessages';
-
-import { useAuthStore } from '@/shared/stores/auth';
 import { ChatRoomHeader } from '@/features/chat-room/ui/ChatRoomHeader';
+
 import { useChatList } from '@/shared/api/client/chat/useChatList';
+import { useAuthStore } from '@/shared/stores/auth';
 
 const ChatPage = () => {
   const { roomId } = useParams();
@@ -16,7 +18,12 @@ const ChatPage = () => {
 
   if (!currentUserId) return <div>로그인이 필요합니다</div>;
   if (typeof roomId !== 'string') return <div>잘못된 접근입니다</div>;
-  if (isLoading || !chatRooms) return <div>채팅방 로딩 중...</div>;
+  if (isLoading || !chatRooms)
+    return (
+      <div className="flex h-full w-full items-center justify-center">
+        <LoadingSpinner />
+      </div>
+    );
 
   const room = chatRooms.find((room) => room.room_id === roomId);
 

--- a/apps/web/app/(test)/admin/hot_deals/page.tsx
+++ b/apps/web/app/(test)/admin/hot_deals/page.tsx
@@ -9,6 +9,8 @@ import { Select } from '@repo/ui/design-system/base-components/Select/index';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { format } from 'date-fns';
 
+import { LoadingSpinner } from '@/widgets/loading-spiner';
+
 import { productDescriptionStyle } from '@/features/auction-add/ui/styles/ProductDescriptionInput.styles';
 
 import { fetchHotdealList } from '@/shared/api/server/hotdeal/fetchHotdealList';
@@ -225,7 +227,12 @@ export default function HotDealsClient() {
     createMutation.mutate(validation.data);
   };
 
-  if (isLoading) return <div>로딩 중...</div>;
+  if (isLoading)
+    return (
+      <div className="flex h-full w-full items-center justify-center">
+        <LoadingSpinner />
+      </div>
+    );
   if (isError) return <div>오류가 발생했습니다: {error.message}</div>;
 
   return (

--- a/apps/web/features/auction-add/ui/AuctionImageUploader.tsx
+++ b/apps/web/features/auction-add/ui/AuctionImageUploader.tsx
@@ -1,33 +1,39 @@
 'use client';
 
-import React, { useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 import { CirclePlus, CircleX } from 'lucide-react';
-
-import { useAuctionImage } from '@/shared/api/client/auction/useAuctionImage';
+import Image from 'next/image';
 
 import { handleImageChange } from '../model/handlers';
 
 import { auctionImageUploaderStyle } from './styles/AuctionImageUploader.styles';
 
 interface AuctionImageUploaderProps {
-  images: string[];
-  setImages: React.Dispatch<React.SetStateAction<string[]>>;
+  files: File[];
+  setFiles: React.Dispatch<React.SetStateAction<File[]>>;
 }
 
-export const AuctionImageUploader: React.FC<AuctionImageUploaderProps> = ({
-  images,
-  setImages,
-}) => {
+export const AuctionImageUploader: React.FC<AuctionImageUploaderProps> = ({ files, setFiles }) => {
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const imageMutation = useAuctionImage();
+  const [imagePreviews, setImagePreviews] = useState<string[]>([]);
+
+  useEffect(() => {
+    const newImagePreviews = files.map((file) => URL.createObjectURL(file));
+    setImagePreviews(newImagePreviews);
+
+    return () => {
+      newImagePreviews.forEach((url) => URL.revokeObjectURL(url));
+    };
+  }, [files]);
+
   const handleImageClick = () => {
-    if (images.length >= 5) return;
+    if (files.length >= 5) return;
     fileInputRef.current?.click();
   };
 
   const handleRemoveImage = (idx: number) => {
-    setImages((prev) => prev.filter((_, i) => i !== idx));
+    setFiles((prev) => prev.filter((_, i) => i !== idx));
   };
 
   return (
@@ -40,15 +46,21 @@ export const AuctionImageUploader: React.FC<AuctionImageUploaderProps> = ({
           accept="image/jpeg,image/png"
           multiple
           className="hidden"
-          onChange={(e) => handleImageChange(e, images, setImages, imageMutation)}
-          disabled={images.length >= 5}
+          onChange={(e) => handleImageChange(e, setFiles)}
+          disabled={files.length >= 5}
         />
       </div>
       {/* 미리보기 썸네일 */}
       <div className={auctionImageUploaderStyle.imagePreviewContainerStyle}>
-        {images.map((url, idx) => (
+        {imagePreviews.map((url, idx) => (
           <div key={idx} className={auctionImageUploaderStyle.imagePreviewStyle}>
-            <img src={url} alt="미리보기" className={auctionImageUploaderStyle.imageStyle} />
+            <Image
+              src={url}
+              alt="미리보기"
+              fill
+              className={auctionImageUploaderStyle.imageStyle}
+              sizes="90"
+            />
             <button
               type="button"
               className={auctionImageUploaderStyle.delateButtonStyle}

--- a/apps/web/features/auction-detail/model/useAuctionBidState.ts
+++ b/apps/web/features/auction-detail/model/useAuctionBidState.ts
@@ -37,12 +37,9 @@ export function useAuctionBidState(auctionId: string) {
 
   useRealtimeBids(
     auctionId,
-    useCallback(
-      (newBid: Bid) => {
-        queryClient.invalidateQueries({ queryKey: ['auctionDetail', auctionId] });
-      },
-      [auctionId, queryClient]
-    )
+    useCallback(() => {
+      queryClient.invalidateQueries({ queryKey: ['auctionDetail', auctionId] });
+    }, [auctionId, queryClient])
   ); // 실시간 입찰 업데이트
 
   const { minusBidCost, plusBidCost } = useBidCostHandlers(

--- a/apps/web/widgets/auction-form/ui/AuctionForm.tsx
+++ b/apps/web/widgets/auction-form/ui/AuctionForm.tsx
@@ -2,6 +2,8 @@ import { Button } from '@repo/ui/design-system/base-components/Button/index';
 import { Input } from '@repo/ui/design-system/base-components/Input/index';
 import { Select } from '@repo/ui/design-system/base-components/Select/index';
 
+import { LoadingSpinner } from '@/widgets/loading-spiner';
+
 import {
   handleDateChange,
   handleInputChange,
@@ -71,7 +73,11 @@ export const AuctionForm = ({ isEdit, auctionId }: AuctionFormProps) => {
   };
 
   if (isLoading) {
-    return <div>로딩중...</div>;
+    return (
+      <div className="flex h-full w-full items-center justify-center">
+        <LoadingSpinner />
+      </div>
+    );
   }
   return (
     <form onSubmit={handleFormSubmit} className={auctionFormStyle.formContainer}>

--- a/apps/web/widgets/auction-form/ui/AuctionForm.tsx
+++ b/apps/web/widgets/auction-form/ui/AuctionForm.tsx
@@ -5,10 +5,10 @@ import { Select } from '@repo/ui/design-system/base-components/Select/index';
 import {
   handleDateChange,
   handleInputChange,
+  handlePriceInput,
   handleSelectChange,
   handleStartPriceInput,
   handleTextareaChange,
-  handlePriceInput,
 } from '@/features/auction-add/model/handlers';
 import { useAuctionForm } from '@/features/auction-add/model/useAuctionForm';
 import { AuctionDateSelector } from '@/features/auction-add/ui/AuctionDateSelector';
@@ -17,6 +17,7 @@ import { ErrorMessage } from '@/features/auction-add/ui/ErrorMessage';
 import { ProductDescriptionInput } from '@/features/auction-add/ui/ProductDescriptionInput';
 
 import { useAuctionDetail } from '@/shared/api/client/auction/useAuctionDetail';
+import { useAuctionImage } from '@/shared/api/client/auction/useAuctionImage';
 import { categories } from '@/shared/mock/auction';
 
 import { auctionFormStyle } from './styles/AuctionForm.styles';
@@ -26,6 +27,7 @@ type AuctionFormProps =
   | { isEdit?: false; auctionId?: undefined };
 export const AuctionForm = ({ isEdit, auctionId }: AuctionFormProps) => {
   const { data: auctionData, isLoading } = useAuctionDetail(isEdit ? auctionId : null);
+  const imageMutation = useAuctionImage();
 
   const {
     auctionName,
@@ -38,8 +40,9 @@ export const AuctionForm = ({ isEdit, auctionId }: AuctionFormProps) => {
     setAuctionCategory,
     auctionDescription,
     setAuctionDescription,
+    files,
+    setFiles,
     images,
-    setImages,
     startDate,
     setStartDate,
     endDate,
@@ -49,21 +52,34 @@ export const AuctionForm = ({ isEdit, auctionId }: AuctionFormProps) => {
     handleSubmit,
   } = useAuctionForm({
     isEdit: isEdit,
-    initialData: isEdit ? auctionData : null, // isEdit일 때만 auctionData를 전달
+    initialData: isEdit ? auctionData : null,
   });
 
+  const handleFormSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    let uploadedImageUrls: string[] = [];
+    if (files.length > 0) {
+      const uploadPromises = files.map((file) => imageMutation.mutateAsync(file));
+      const results = await Promise.all(uploadPromises);
+      uploadedImageUrls = results.filter((url): url is string => !!url);
+    }
+
+    const finalImages = [...images, ...uploadedImageUrls];
+
+    handleSubmit(e, finalImages);
+  };
+
   if (isLoading) {
-    return <div>로딩중...</div>; // return 문 추가
+    return <div>로딩중...</div>;
   }
   return (
-    <form onSubmit={handleSubmit} className={auctionFormStyle.formContainer}>
-      {/*사진 등록 및 위치*/}
+    <form onSubmit={handleFormSubmit} className={auctionFormStyle.formContainer}>
       <fieldset>
-        <AuctionImageUploader images={images} setImages={setImages} />
+        <AuctionImageUploader files={files} setFiles={setFiles} />
         <ErrorMessage message={fieldErrors.images} />
       </fieldset>
 
-      {/*경매 정보 입력*/}
       <fieldset>
         <Input
           label="경매 이름"
@@ -90,7 +106,15 @@ export const AuctionForm = ({ isEdit, auctionId }: AuctionFormProps) => {
         <Input
           label="경매 시작가"
           value={startPrice}
-          onChange={(e) => handleStartPriceInput(e, setStartPrice, setFieldErrors)}
+          onChange={(e) =>
+            handleStartPriceInput(
+              e,
+              setStartPrice,
+              setFieldErrors,
+              isEdit ? auctionData?.current_price : undefined,
+              isEdit ? auctionData?.bid_count : undefined
+            )
+          }
         />
         <ErrorMessage message={fieldErrors.startPrice} />
       </fieldset>
@@ -103,7 +127,6 @@ export const AuctionForm = ({ isEdit, auctionId }: AuctionFormProps) => {
         <ErrorMessage message={fieldErrors.bidUnitPrice} />
       </fieldset>
 
-      {/* 날짜 선택 컴포넌트 */}
       <fieldset>
         <AuctionDateSelector
           startDate={startDate}
@@ -114,7 +137,6 @@ export const AuctionForm = ({ isEdit, auctionId }: AuctionFormProps) => {
         <ErrorMessage message={fieldErrors.startDate || fieldErrors.endDate} />
       </fieldset>
 
-      {/* 상품 정보 입력 */}
       <fieldset>
         <ProductDescriptionInput
           value={auctionDescription}
@@ -125,7 +147,7 @@ export const AuctionForm = ({ isEdit, auctionId }: AuctionFormProps) => {
         <ErrorMessage message={fieldErrors.auctionDescription} />
       </fieldset>
 
-      <Button variants="primary" type="submit" size="thinLg">
+      <Button variants="primary" type="submit" size="thinLg" disabled={imageMutation.isPending}>
         {isEdit ? '수정 하기' : '경매 등록'}
       </Button>
     </form>

--- a/apps/web/widgets/hotdeal-info-card/ui/HotdealInfoCard.tsx
+++ b/apps/web/widgets/hotdeal-info-card/ui/HotdealInfoCard.tsx
@@ -1,6 +1,10 @@
+import Image from 'next/image';
+
+import { ProgressBar } from '@/widgets/progress-bar';
+
 import { getGradeIcon } from '@/shared/lib/points/getGradeIcon';
 import { HotDeal } from '@/shared/types/db';
-import { ProgressBar } from '@/widgets/progress-bar';
+
 import { HotdealInfoCardStyles } from './HotdealInfoCard.styles';
 
 interface HotdealInfoCardProps {
@@ -32,7 +36,15 @@ export const HotdealInfoCard = ({ data, countdown }: HotdealInfoCardProps) => {
   return (
     <div>
       <div className={HotdealInfoCardStyles.infoContainerStyle}>
-        <img src={data.image_url} alt={data.name} />
+        <div className="relative h-52 w-full">
+          <Image
+            src={data.image_url}
+            alt={data.name}
+            fill
+            sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+            style={{ objectFit: 'contain' }}
+          />
+        </div>
         <div className={HotdealInfoCardStyles.infoCardContainerStyle}>
           <div className={HotdealInfoCardStyles.infoNameStyle}>{data.name}</div>
 

--- a/apps/web/widgets/image-banner/ui/ImageBanner.tsx
+++ b/apps/web/widgets/image-banner/ui/ImageBanner.tsx
@@ -1,20 +1,29 @@
 'use client';
 
+import Image from 'next/image';
 import 'swiper/css';
 import 'swiper/css/navigation';
 import 'swiper/css/pagination';
 import { Autoplay, Navigation, Pagination } from 'swiper/modules';
 import { Swiper, SwiperSlide } from 'swiper/react';
+
 import { Styles } from './styles/image-banner.styles';
+
 import './styles/swiper-custom.css';
 
 interface ImageBannerProps {
   images: string[];
   height?: number | string;
   autoplay?: boolean;
+  altText?: string;
 }
 
-export const ImageBanner = ({ images, autoplay = false, height = 230 }: ImageBannerProps) => {
+export const ImageBanner = ({
+  images,
+  autoplay = false,
+  height = 230,
+  altText = '배너 이미지',
+}: ImageBannerProps) => {
   return (
     <Swiper
       style={{ height }}
@@ -26,10 +35,17 @@ export const ImageBanner = ({ images, autoplay = false, height = 230 }: ImageBan
       modules={[Navigation, Pagination, Autoplay]}
       className={Styles.swiperContainer}
     >
-      {images.map((image) => (
-        <SwiperSlide key={image}>
+      {images.map((image, index) => (
+        <SwiperSlide key={image + index}>
           <div className={Styles.slideContainer}>
-            <img src={image} alt={image} className={Styles.image} />
+            <Image
+              src={image}
+              alt={`${altText} ${index + 1}`}
+              fill
+              sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+              className={Styles.image}
+              priority={index === 0} // 첫 번째 이미지만 우선적으로 로드
+            />
           </div>
         </SwiperSlide>
       ))}

--- a/apps/web/widgets/image-banner/ui/styles/image-banner.styles.ts
+++ b/apps/web/widgets/image-banner/ui/styles/image-banner.styles.ts
@@ -1,5 +1,5 @@
 export const Styles = {
   swiperContainer: 'bg-[var(--bg-secondary)] w-full rounded-[var(--radius-md)] border-none',
-  slideContainer: 'flex w-full h-full items-center justify-center',
+  slideContainer: 'relative flex w-full h-full items-center justify-center',
   image: 'h-auto w-full max-w-full object-contain',
 };

--- a/packages/ui/src/design-system/base-components/Button/Button.tsx
+++ b/packages/ui/src/design-system/base-components/Button/Button.tsx
@@ -15,9 +15,9 @@ export interface ButtonProps {
 const buttonStyle = {
   buttonVariantClasses: {
     primary:
-      'bg-purple-500 text-white transition-colors hover:bg-purple-600 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:ring-offset-2',
+      'bg-primary-500 text-white transition-colors hover:bg-primary-100 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2',
     secondary:
-      'bg-[var(--button-secondary-bg)] text-[var(--button-secondary-text)] hover:bg-[var(--button-secondary-bg-hover)] active:bg-[var(--button-secondary-bg-active)] ',
+      'bg-[var(--button-secondary-bg)] text-white hover:bg-[var(--button-secondary-bg-hover)] active:bg-[var(--button-secondary-bg-active)] ',
     outline:
       'bg-[var(--button-outline-bg)] text-[var(--button-outline-text)] border border-[var(--button-outline-border)] hover:bg-[var(--button-outline-bg-hover)] ',
     ghost:

--- a/packages/ui/src/utils/getTimeLeftString.ts
+++ b/packages/ui/src/utils/getTimeLeftString.ts
@@ -50,8 +50,8 @@ export function getTimeLeftString({
     return '유효하지 않은 종료 날짜';
   }
 
-  // 경매 진행 중 또는 종료
-  const diff = end.getTime() - now.getTime();
+  const targetDate = start && now < start ? start : end;
+  const diff = targetDate.getTime() - now.getTime();
 
   if (diff <= 0) {
     return '00:00';


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용
경매 등록 과정에서 이미지 추가 시 기존 storage 등록 후에 url을 가져와서 미리보기 하는 방식에서
input의 파일 url로 미리보기 하게끔 변경하고 경매 등록 시, storage 등록, confirm을 통해 최종 등록 하도록 변경했습니다.
경매 리스트, 상세 페이지에서 사용되는 시간 계산 로직에서 경매 시작 전임에도 경매 종료 시간까지 남은 시간으로 계산되던 로직을 수정했습니다.

경매 상세, 등록 페이지(미리보기), 핫딜 상세 페이지의 img 태그를 Image 컴포넌트로 변경했습니다.

전체적으로 로딩스피너가 적용 안된 부분에 로딩 스피너를 적용했습니다.

## 🔧 변경 사항
- 경매 등록 시 이미지 미리보기 및 이미지 저장 로직 변경
- 경매, 핫딜 상세 페이지, 등록 페이지의 미리보기에서 사용하는 img 태그를 next Image 컴포넌트로 변경
- 로딩 스피너 미적용 된 부분 스피너 적용

## 📸 스크린샷 (선택 사항)

## 📄 기타
