### PR TITLE
[fix]: 메인 레이아웃 높이 계산 방식 변경

### DIFF
--- a/apps/web/app/(main)/hotdeal/[hotdealId]/detail/page.tsx
+++ b/apps/web/app/(main)/hotdeal/[hotdealId]/detail/page.tsx
@@ -6,7 +6,7 @@ import { Button } from '@repo/ui/design-system/base-components/Button/index';
 import toast from 'react-hot-toast';
 
 import { HotdealInfoCard } from '@/widgets/hotdeal-info-card';
-import { LoadingSpinner } from '@/widgets/loading-spiner';
+import { HotdealInfoCardSkeleton } from '@/widgets/hotdeal-info-card/ui/HotdealInfoCardSkeleton';
 
 import { useHotdealCountdownLogic } from '@/features/hotdeal/model/useHotdealCountdownLogic';
 import { useHotdealRealtime } from '@/features/hotdeal/model/useHotdealRealtime';
@@ -15,8 +15,6 @@ import { useHotdealDetailQuery } from '@/shared/api/client/hotdeal/useHotdealDet
 import { usePurchaseHotdeal } from '@/shared/api/client/hotdeal/usePurchaseHotdeal';
 import { useUserProfileDataQuery } from '@/shared/api/client/profile/useUserProfileDataQuery';
 import { useAuthStore } from '@/shared/stores/auth';
-
-import { HotdealInfoCardSkeleton } from '@/widgets/hotdeal-info-card/ui/HotdealInfoCardSkeleton';
 
 const GRADE_ORDER = ['흙', '돌멩이', '에벌레', '씨앗', '새싹', '나무', '숲'];
 
@@ -85,7 +83,7 @@ export default function Page({ params }: { params: Promise<{ hotdealId: string }
 
       <Button
         variants="primary"
-        className="sticky bottom-1"
+        className="sticky bottom-20"
         size="thinLg"
         onClick={handlePurchase}
         disabled={status !== 'ACTIVE' || purchaseMutation.isPending}

--- a/apps/web/app/(main)/layout.tsx
+++ b/apps/web/app/(main)/layout.tsx
@@ -13,13 +13,10 @@ const layout = ({ children }: Props) => {
     <div className="flex h-screen flex-col">
       <Header />
       <ModalProvider />
-      <div
-        id="main-scroll-container"
-        className="relative h-[calc(100dvh-68px-80px)] overflow-y-auto px-4"
-      >
+      <main id="main-scroll-container" className="relative flex-1 overflow-y-auto px-4">
         {children}
         <ScrollButton />
-      </div>
+      </main>
       <Footer />
     </div>
   );

--- a/apps/web/widgets/scroll-button/ScrollButton.styles.ts
+++ b/apps/web/widgets/scroll-button/ScrollButton.styles.ts
@@ -1,5 +1,5 @@
 export const ScrollButtonStyle = {
-  container: 'z-30 sticky bottom-2 right-0 float-right',
+  container: 'z-30 sticky bottom-22 right-0 float-right',
   button:
     'rounded-full bg-[var(--button-primary-bg)] p-2.5 text-[var(--button-primary-text)] hover:bg-[var(--button-primary-bg-hover)]',
 };


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용
모바일 환경 스크롤가능한 페이지 새로고침 시, sticky 버튼이 제대로 보이지 않는 현상을 수정했습니다.
모바일 환경에서 100dvh를 통해 절대 값이 아닌 상대값으로 계산을 시작해 달라질 수 있는 header와 footer의 높이를 px단위로 계산했던 것이 문제였습니다.

## 🔧 변경 사항
- calc를 통해 h값을 계산하던 방식에서 이전 사용했던 flex방식으로 변경

## 📸 스크린샷 (선택 사항)

## 📄 기타
