### PR TITLE
[refactor]: 경매 카테고리 bg 적용 안되는 현상 해결

### DIFF
--- a/apps/web/app/(auth)/callback/page.tsx
+++ b/apps/web/app/(auth)/callback/page.tsx
@@ -1,9 +1,11 @@
 // callback/page.tsx
 'use client';
 
-import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
-import { supabase } from '../../../shared/lib/supabase/supabase';
+
+import { useRouter } from 'next/navigation';
+
+import { supabase } from '@/shared/lib/supabase/supabase';
 
 const AuthCallbackPage = () => {
   const router = useRouter();

--- a/apps/web/app/(auth)/dashboard/page.tsx
+++ b/apps/web/app/(auth)/dashboard/page.tsx
@@ -1,8 +1,10 @@
 'use client';
 
-import { useAuthStore } from '@/shared/stores/auth';
-import { useRouter } from 'next/navigation';
 import { useState } from 'react';
+
+import { useRouter } from 'next/navigation';
+
+import { useAuthStore } from '@/shared/stores/auth';
 
 export default function DashboardPage() {
   const router = useRouter();

--- a/apps/web/app/(main)/auction/auction-list/page.tsx
+++ b/apps/web/app/(main)/auction/auction-list/page.tsx
@@ -23,7 +23,7 @@ const Page = () => {
     hasNextPage,
     isFetchingNextPage,
   } = useAuctionList();
-  const [selectedCategory, setSelectedCategory] = useState<string>('all');
+  const [selectedCategory, setSelectedCategory] = useState<string>('전체');
   const [selectedBadge, setSelectedBadge] = useState<string>('all');
   const { ref } = useInView({
     threshold: 0.5,
@@ -40,7 +40,7 @@ const Page = () => {
   // 기본적으로 종료된 경매(status === 'end')는 필터링하여 제외
   let filteredList = mappedList.filter((item) => item.status !== 'closed');
 
-  if (!(selectedCategory === 'all' || selectedCategory === '전체')) {
+  if (!(selectedCategory === '전체')) {
     filteredList = filteredList.filter((item) => item.category === selectedCategory);
   }
   if (selectedBadge !== 'all') {
@@ -55,7 +55,8 @@ const Page = () => {
       <SearchInput setCategory={setSelectedCategory} />
       <Category
         categories={categories}
-        onCategoryClick={(cat) => setSelectedCategory(cat === '전체' ? 'all' : cat)}
+        selectedCategory={selectedCategory}
+        onCategoryClick={(cat) => setSelectedCategory(cat === '전체' ? '전체' : cat)}
       />
       <select
         name="listFilter"

--- a/apps/web/app/(main)/layout.tsx
+++ b/apps/web/app/(main)/layout.tsx
@@ -1,8 +1,7 @@
+import { Footer } from '@/widgets/footer';
+import { Header } from '@/widgets/header';
 import ModalProvider from '@/widgets/modal/ui/ModalProvider';
 import { ScrollButton } from '@/widgets/scroll-button/ScrollButton';
-
-import { Footer } from '../../widgets/footer';
-import { Header } from '../../widgets/header';
 
 interface Props {
   children: React.ReactNode;

--- a/apps/web/app/(no-footer)/layout.tsx
+++ b/apps/web/app/(no-footer)/layout.tsx
@@ -1,7 +1,6 @@
+import { Header } from '@/widgets/header';
 import ModalProvider from '@/widgets/modal/ui/ModalProvider';
 import { ScrollButton } from '@/widgets/scroll-button/ScrollButton';
-
-import { Header } from '../../widgets/header';
 
 interface Props {
   children: React.ReactNode;

--- a/apps/web/app/api/auction/bidder-name/route.ts
+++ b/apps/web/app/api/auction/bidder-name/route.ts
@@ -1,5 +1,6 @@
-import { adminClient } from '@/app/admin';
 import { NextRequest, NextResponse } from 'next/server';
+
+import { adminClient } from '@/app/admin';
 
 export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url);

--- a/apps/web/app/api/auction/delete/[auctionId]/route.ts
+++ b/apps/web/app/api/auction/delete/[auctionId]/route.ts
@@ -1,5 +1,6 @@
-import { adminClient } from '@/app/admin';
 import { NextResponse } from 'next/server';
+
+import { adminClient } from '@/app/admin';
 
 export async function DELETE(req: Request, { params }: { params: { auctionId: string } }) {
   try {

--- a/apps/web/features/chat-list/model/Authenticated.tsx
+++ b/apps/web/features/chat-list/model/Authenticated.tsx
@@ -1,8 +1,10 @@
 'use client';
 
-import { useAuthStore } from '@/shared/stores/auth';
-import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
+
+import { useRouter } from 'next/navigation';
+
+import { useAuthStore } from '@/shared/stores/auth';
 
 interface Props {
   children: (userId: string) => React.ReactNode;

--- a/apps/web/features/hotdeal/model/useHotdealRealtime.ts
+++ b/apps/web/features/hotdeal/model/useHotdealRealtime.ts
@@ -1,16 +1,8 @@
-import { createClient } from '@/app/client';
-import { useQueryClient } from '@tanstack/react-query';
 import { useEffect } from 'react';
 
-// payload 타입 정의
-interface RealtimePayload {
-  eventType: 'UPDATE';
-  schema: 'public';
-  table: 'hot_deals';
-  commit_timestamp: string;
-  old: Record<string, any>; // 업데이트 전 데이터 (primary key만 포함될 수 있음)
-  new: Record<string, any>; // 업데이트 후 데이터
-}
+import { useQueryClient } from '@tanstack/react-query';
+
+import { createClient } from '@/app/client';
 
 export const useHotdealRealtime = (hotdealId: string) => {
   const queryClient = useQueryClient();
@@ -27,9 +19,7 @@ export const useHotdealRealtime = (hotdealId: string) => {
           table: 'hot_deals',
           filter: `id=eq.${hotdealId}`,
         },
-        (payload: RealtimePayload) => {
-          // payload에 타입 적용
-          console.log('Realtime update received for hotdeal:', payload);
+        () => {
           // hotdealDetail 쿼리 무효화하여 최신 데이터 다시 가져오기
           queryClient.invalidateQueries({ queryKey: ['hotdealDetail', hotdealId] });
         }

--- a/apps/web/features/hotdeal/ui/HotdealListItemSkeleton.tsx
+++ b/apps/web/features/hotdeal/ui/HotdealListItemSkeleton.tsx
@@ -1,6 +1,6 @@
 import { Skeleton } from '@repo/ui/design-system/base-components/Skeleton/index';
 
-import { AuctionListItemStyles } from '../../../features/auction/ui/styles/AuctionListItem.styles';
+import { AuctionListItemStyles } from '@/features/auction/ui/styles/AuctionListItem.styles';
 
 export const HotdealListItemSkeleton = () => {
   return (

--- a/apps/web/features/product-list/ui/ProductCard.tsx
+++ b/apps/web/features/product-list/ui/ProductCard.tsx
@@ -10,13 +10,13 @@ import {
   Sparkles,
   Stamp,
   Tv,
-  type LucideProps,
   Watch,
+  type LucideProps,
 } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
 
-import { Product } from '../../../widgets/product-section/types';
+import { Product } from '@/widgets/product-section/types';
 
 import { Styles } from './styles/product-card.styles';
 

--- a/apps/web/shared/api/client/auction/useAuctionBid.ts
+++ b/apps/web/shared/api/client/auction/useAuctionBid.ts
@@ -1,9 +1,8 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import toast from 'react-hot-toast';
 
+import { postAuctionBid } from '@/shared/api/server/auction/postAuctionBid';
 import { AuctionBidParams, AuctionBidResponse } from '@/shared/types/auction';
-
-import { postAuctionBid } from '../../server/auction/postAuctionBid';
 
 export function useAuctionBid() {
   const queryClient = useQueryClient();

--- a/apps/web/shared/api/client/auction/useAuctionDetail.ts
+++ b/apps/web/shared/api/client/auction/useAuctionDetail.ts
@@ -1,8 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 
+import { fetchAuctionDetail } from '@/shared/api/server/auction/fetchAuctionDetail';
 import { AuctionDetail } from '@/shared/types/db';
-
-import { fetchAuctionDetail } from '../../server/auction/fetchAuctionDetail';
 
 export function useAuctionDetail(auctionId: string | null) {
   return useQuery<AuctionDetail, Error>({

--- a/apps/web/shared/api/client/auction/useAuctionImage.ts
+++ b/apps/web/shared/api/client/auction/useAuctionImage.ts
@@ -1,7 +1,7 @@
 import { useMutation } from '@tanstack/react-query';
 import toast from 'react-hot-toast';
 
-import { postAuctionImages } from '../../server/auction/postAuctionImages';
+import { postAuctionImages } from '@/shared/api/server/auction/postAuctionImages';
 
 export const useAuctionImage = () => {
   return useMutation<string, Error, File>({

--- a/apps/web/shared/api/client/auction/useAuctionList.ts
+++ b/apps/web/shared/api/client/auction/useAuctionList.ts
@@ -1,7 +1,10 @@
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { useSearchParams } from 'next/navigation';
 
-import { AuctionListQueryKey, fetchAuctionList } from '../../server/auction/fetchAuctionList';
+import {
+  AuctionListQueryKey,
+  fetchAuctionList,
+} from '@/shared/api/server/auction/fetchAuctionList';
 
 export const useAuctionList = () => {
   const searchParams = useSearchParams();

--- a/apps/web/shared/api/client/auction/useCreateAuction.ts
+++ b/apps/web/shared/api/client/auction/useCreateAuction.ts
@@ -2,9 +2,8 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import toast from 'react-hot-toast';
 
+import { postAuctionAdd } from '@/shared/api/server/auction/postAuctionAdd';
 import { CreateAuctionPayload } from '@/shared/types/auction';
-
-import { postAuctionAdd } from '../../server/auction/postAuctionAdd';
 
 export function useCreateAuction() {
   const queryClient = useQueryClient();

--- a/apps/web/shared/api/client/auction/useDeleteAuction.ts
+++ b/apps/web/shared/api/client/auction/useDeleteAuction.ts
@@ -2,7 +2,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import toast from 'react-hot-toast';
 
-import { deleteAuction } from '../../server/auction/deleteAuction';
+import { deleteAuction } from '@/shared/api/server/auction/deleteAuction';
 
 export const useDeleteAuction = () => {
   const queryClient = useQueryClient();

--- a/apps/web/shared/api/client/auction/useMyWonAuctions.ts
+++ b/apps/web/shared/api/client/auction/useMyWonAuctions.ts
@@ -1,5 +1,6 @@
-import { AuctionItem } from '@/shared/types/auction';
 import { useQuery } from '@tanstack/react-query';
+
+import { AuctionItem } from '@/shared/types/auction';
 
 export const useMyWonAuctions = (userId: string) => {
   return useQuery<AuctionItem[]>({

--- a/apps/web/shared/api/client/auction/useUpdateAuction.ts
+++ b/apps/web/shared/api/client/auction/useUpdateAuction.ts
@@ -2,7 +2,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import toast from 'react-hot-toast';
 
-import { updateAuction } from '../../server/auction/updateAuction';
+import { updateAuction } from '@/shared/api/server/auction/updateAuction';
 
 export const useUpdateAuction = () => {
   const queryClient = useQueryClient();

--- a/apps/web/shared/api/client/chat/useChatRoomHeader.ts
+++ b/apps/web/shared/api/client/chat/useChatRoomHeader.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 
-import { fetchChatRoomHeader } from '../../server/chat/fetchChatRoomHeader';
+import { fetchChatRoomHeader } from '@/shared/api/server/chat/fetchChatRoomHeader';
 
 export const useChatRoomHeader = (userId: string) => {
   return useQuery({

--- a/apps/web/shared/api/client/hotdeal/useHotdealDetail.ts
+++ b/apps/web/shared/api/client/hotdeal/useHotdealDetail.ts
@@ -1,6 +1,7 @@
-import { HotDeal } from '@/shared/types/db';
 import { useQuery } from '@tanstack/react-query';
-import { fetchHotdealDetail } from '../../server/hotdeal/fetchHotdealDetail';
+
+import { fetchHotdealDetail } from '@/shared/api/server/hotdeal/fetchHotdealDetail';
+import { HotDeal } from '@/shared/types/db';
 
 export function useHotdealDetailQuery(hotdealId: string) {
   return useQuery<HotDeal, Error>({

--- a/apps/web/shared/api/client/hotdeal/useHotdealList.ts
+++ b/apps/web/shared/api/client/hotdeal/useHotdealList.ts
@@ -1,8 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 
+import { fetchHotdealList } from '@/shared/api/server/hotdeal/fetchHotdealList';
 import { HotDeal } from '@/shared/types/db';
-
-import { fetchHotdealList } from '../../server/hotdeal/fetchHotdealList';
 
 export const useHotdealList = () => {
   return useQuery<(HotDeal & { status: string })[]>({

--- a/apps/web/shared/api/client/notification/useNotificationList.ts
+++ b/apps/web/shared/api/client/notification/useNotificationList.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
-import { fetchNotificationList } from '../../server/notification/fetchNotificationList';
+
+import { fetchNotificationList } from '@/shared/api/server/notification/fetchNotificationList';
 
 export const useNotificationList = (isModalOpen: boolean) => {
   return useQuery({

--- a/apps/web/shared/api/client/push/usePushSubscription.ts
+++ b/apps/web/shared/api/client/push/usePushSubscription.ts
@@ -1,7 +1,7 @@
 import { useMutation } from '@tanstack/react-query';
 import toast from 'react-hot-toast';
 
-import { sendSubscriptionToServer } from '../../server/push/sendSubscriptionToServer';
+import { sendSubscriptionToServer } from '@/shared/api/server/push/sendSubscriptionToServer';
 
 export const usePushSubscription = () => {
   return useMutation({

--- a/apps/web/shared/api/client/push/usePushUnsubscription.ts
+++ b/apps/web/shared/api/client/push/usePushUnsubscription.ts
@@ -1,7 +1,7 @@
 import { useMutation } from '@tanstack/react-query';
 import toast from 'react-hot-toast';
 
-import { sendUnsubscriptionToServer } from '../../server/push/sendUnsubscriptionToServer';
+import { sendUnsubscriptionToServer } from '@/shared/api/server/push/sendUnsubscriptionToServer';
 
 export const usePushUnsubscription = () => {
   return useMutation({

--- a/apps/web/widgets/header/ui/Header.tsx
+++ b/apps/web/widgets/header/ui/Header.tsx
@@ -8,8 +8,8 @@ import { usePathname, useRouter } from 'next/navigation';
 
 import { useAuthStore } from '@/shared/stores/auth';
 import { useHeaderStore } from '@/shared/stores/headerStore';
+import { useModalStore } from '@/shared/stores/modal';
 
-import { useModalStore } from '../../../shared/stores/modal';
 import { headerStyles as styles } from '../styles/header.styles';
 
 export const Header = () => {

--- a/apps/web/widgets/product-section/ui/ProductSection.tsx
+++ b/apps/web/widgets/product-section/ui/ProductSection.tsx
@@ -1,15 +1,14 @@
 import { ProductCardSkeleton } from '@/features/product-list/ui/ProductCardSkeleton';
+import { ProductList } from '@/features/product-list/ui/ProductList';
 
-import { ProductList } from '../../../features/product-list/ui/ProductList';
 import type { Product } from '../types';
 
 interface ProductSectionProps {
   products?: Product[];
   isLoading: boolean;
-  className?: string;
 }
 
-export const ProductSection = ({ products, isLoading, className = '' }: ProductSectionProps) => {
+export const ProductSection = ({ products, isLoading }: ProductSectionProps) => {
   if (isLoading || !products) {
     return <ProductCardSkeleton />;
   }

--- a/apps/web/widgets/profile/ui/ProfileForm.tsx
+++ b/apps/web/widgets/profile/ui/ProfileForm.tsx
@@ -8,6 +8,7 @@ import { ZodFormattedError } from 'zod';
 
 import { handleInputChange, handleSubmit } from '@/features/profile/model/handlers';
 import { ProfileAvatarUpload } from '@/features/profile/ui/ProfileAvatarUpload';
+
 import { useUpdateProfile } from '@/shared/api/client/profile/useUpdateProfile';
 import { getCacheBustingUrl } from '@/shared/lib/utils/avatar';
 import { ProfileFormType, UserProfileType } from '@/shared/types/profile';

--- a/apps/web/widgets/search/ui/SearchInput.tsx
+++ b/apps/web/widgets/search/ui/SearchInput.tsx
@@ -2,10 +2,10 @@
 import { Dispatch, SetStateAction, useState } from 'react';
 
 import { Button } from '@repo/ui/design-system/base-components/Button/index';
+import { Input } from '@repo/ui/design-system/base-components/Input/index';
 import { X } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 
-import { Input } from '../../../../../packages/ui/src/design-system/base-components/Input/Input';
 import { searchInputStyles } from '../styles/searchInput.styles';
 
 interface Props {


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안
close #395 
<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용
경매 리스트 카테고리 선택 시 color 적용 되도록 누락된 props를 추가했습니다.
추가로 상대 경로 import 를 `../../` 2depth 이상 다른 폴더로 이동하는 경우 절대 경로를 사용하도록 변경했습니다.

## 🔧 변경 사항
- 경매 리스트 선택 된 카테고리 bg 적용 안되는 문제 해결
- 상대 경로 import 일부 절대 경로로 변경

## 📸 스크린샷 (선택 사항)

## 📄 기타
